### PR TITLE
Add OWASP mapping tables and mitigation utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,0 +1,5 @@
+"""OP-Observe core package placeholder."""
+
+__all__ = [
+    "agentic_security",
+]

--- a/op_observe/agentic_security/__init__.py
+++ b/op_observe/agentic_security/__init__.py
@@ -1,0 +1,29 @@
+"""Agentic security OWASP mapping utilities."""
+
+from .loader import (
+    get_agentic_ai_mapping,
+    get_llm_top10_mapping,
+    list_agentic_ai_versions,
+    list_llm_top10_versions,
+)
+from .mapper import map_finding_to_tables
+from .mitigations import generate_mitigation_checklist
+from .models import (
+    MappingTable,
+    RadarFinding,
+    FindingMapping,
+    MitigationChecklistEntry,
+)
+
+__all__ = [
+    "FindingMapping",
+    "MappingTable",
+    "MitigationChecklistEntry",
+    "RadarFinding",
+    "generate_mitigation_checklist",
+    "get_agentic_ai_mapping",
+    "get_llm_top10_mapping",
+    "list_agentic_ai_versions",
+    "list_llm_top10_versions",
+    "map_finding_to_tables",
+]

--- a/op_observe/agentic_security/data/owasp_agentic_ai/v2024.1.json
+++ b/op_observe/agentic_security/data/owasp_agentic_ai/v2024.1.json
@@ -1,0 +1,148 @@
+{
+  "scheme": "OWASP-Agentic",
+  "version": "2024.1",
+  "published": "2024-05-20",
+  "source": "OWASP Agentic AI Security Top 10 (draft)",
+  "categories": [
+    {
+      "id": "AA01",
+      "name": "Unsafe Goal Alignment",
+      "description": "Agent pursues objectives that diverge from policy or user intent.",
+      "matchers": {
+        "tags": ["goal_drift", "misaligned_objective", "unchecked_planner"],
+        "detectors": ["planner_policy_diff", "goal_drift_monitor"]
+      },
+      "mitigations": [
+        "Constrain planning policies and require human approval for goal changes.",
+        "Continuously evaluate goal alignment using automated checks or critics.",
+        "Log planner rationale for audit and debugging."
+      ]
+    },
+    {
+      "id": "AA02",
+      "name": "Toolchain Abuse",
+      "description": "Agent orchestrates tools in a way that causes harm or violates policy.",
+      "matchers": {
+        "tags": ["tool_abuse", "dangerous_chain", "unsafe_tool_combo"],
+        "detectors": ["tool_abuse_probe", "chain_risk_review"]
+      },
+      "mitigations": [
+        "Define explicit allow- and deny-lists for tool sequences.",
+        "Add runtime guardrails to intercept risky tool orchestrations.",
+        "Simulate agent plans under adversarial conditions prior to release."
+      ]
+    },
+    {
+      "id": "AA03",
+      "name": "Environment Escape",
+      "description": "Agent bypasses sandbox boundaries or executes commands on unintended systems.",
+      "matchers": {
+        "tags": ["sandbox_escape", "unauthorized_command", "runtime_breakout"],
+        "detectors": ["sandbox_monitor", "command_policy_violation"]
+      },
+      "mitigations": [
+        "Isolate execution environments with strict OS-level sandboxing.",
+        "Audit command logs and alert on privileged operations.",
+        "Disable shell/tool access by default unless explicitly required."
+      ]
+    },
+    {
+      "id": "AA04",
+      "name": "Sensitive Data Exfiltration",
+      "description": "Agent actions extract or leak confidential data through tools or channels.",
+      "matchers": {
+        "tags": ["agent_data_exfil", "sensitive_tool_output", "mcp_data_leak"],
+        "detectors": ["data_loss_monitor", "mcp_dlp_check"]
+      },
+      "mitigations": [
+        "Enforce data loss prevention controls on all agent interfaces.",
+        "Limit which connectors can handle sensitive data sets.",
+        "Record evidence bundles for all high-risk tool invocations."
+      ]
+    },
+    {
+      "id": "AA05",
+      "name": "Identity & Access Misuse",
+      "description": "Agent or tool uses credentials or permissions inappropriately.",
+      "matchers": {
+        "tags": ["credential_misuse", "privilege_escalation", "token_scope_gap"],
+        "detectors": ["iam_scope_checker", "token_leak_probe"]
+      },
+      "mitigations": [
+        "Issue short-lived credentials scoped to each agent task.",
+        "Rotate secrets and require mutual TLS for service calls.",
+        "Monitor for abnormal access patterns across tenants."
+      ]
+    },
+    {
+      "id": "AA06",
+      "name": "Supply Chain Exposure",
+      "description": "Agent integrates MCP servers or packages with unresolved vulnerabilities.",
+      "matchers": {
+        "tags": ["mcp_vulnerability", "integration_trust_gap", "unverified_dependency"],
+        "detectors": ["mcp_security_review", "integration_sbom_scan"]
+      },
+      "mitigations": [
+        "Perform security reviews on MCP servers before granting access.",
+        "Version-lock connectors and check advisories before upgrade.",
+        "Track dependency attestations and provenance."
+      ]
+    },
+    {
+      "id": "AA07",
+      "name": "Observation & Logging Gaps",
+      "description": "Insufficient telemetry prevents detection or investigation of agent behavior.",
+      "matchers": {
+        "tags": ["logging_gap", "missing_trace", "telemetry_blindspot"],
+        "detectors": ["otel_coverage_gap", "trace_drop_monitor"]
+      },
+      "mitigations": [
+        "Instrument all agent steps and tool calls with OpenTelemetry spans.",
+        "Alert on trace drop rates and gaps in guardrail coverage.",
+        "Retain security evidence bundles for regulated workloads."
+      ]
+    },
+    {
+      "id": "AA08",
+      "name": "Human Oversight Failure",
+      "description": "Critical agent actions proceed without required review or approvals.",
+      "matchers": {
+        "tags": ["no_human_in_loop", "approval_bypass", "unsafe_autonomy"],
+        "detectors": ["approval_workflow_gap", "autonomy_threshold_breach"]
+      },
+      "mitigations": [
+        "Enforce step-up approvals for destructive or high-impact actions.",
+        "Provide operators dashboards summarizing agent decisions and context.",
+        "Simulate oversight workflows during incident response drills."
+      ]
+    },
+    {
+      "id": "AA09",
+      "name": "Evaluation & Guardrail Drift",
+      "description": "Safety checks or evals lose effectiveness over time without monitoring.",
+      "matchers": {
+        "tags": ["guardrail_drift", "eval_regression", "policy_gap"],
+        "detectors": ["guardrail_monitor", "eval_regression_test"]
+      },
+      "mitigations": [
+        "Schedule recurring evals with representative workloads.",
+        "Fail CI when guardrail coverage decreases or regressions appear.",
+        "Version guardrail policies and document changes."
+      ]
+    },
+    {
+      "id": "AA10",
+      "name": "Incident Response Readiness",
+      "description": "Lack of playbooks or automation hinders response to agent failures.",
+      "matchers": {
+        "tags": ["ir_gap", "missing_playbook", "response_delay"],
+        "detectors": ["ir_drill_failure", "playbook_coverage_gap"]
+      },
+      "mitigations": [
+        "Develop and rehearse agent-specific incident playbooks.",
+        "Automate containment actions such as disabling risky tools.",
+        "Capture post-incident learnings and feed them into policy updates."
+      ]
+    }
+  ]
+}

--- a/op_observe/agentic_security/data/owasp_llm_top10/v2024.1.json
+++ b/op_observe/agentic_security/data/owasp_llm_top10/v2024.1.json
@@ -1,0 +1,148 @@
+{
+  "scheme": "OWASP-LLM",
+  "version": "2024.1",
+  "published": "2024-04-24",
+  "source": "OWASP Top 10 for LLM Applications 2024",
+  "categories": [
+    {
+      "id": "LLM01",
+      "name": "Prompt Injection",
+      "description": "Attacker controlled input alters model instructions or reveals hidden prompts.",
+      "matchers": {
+        "tags": ["prompt_injection", "jailbreak", "untrusted_input"],
+        "detectors": ["prompt_injection_scanner", "jailbreak_probe"]
+      },
+      "mitigations": [
+        "Apply strict input validation and context isolation for prompts.",
+        "Use content filters or guard models to screen user supplied inputs.",
+        "Segment system prompts and prevent runtime editing."
+      ]
+    },
+    {
+      "id": "LLM02",
+      "name": "Insecure Output Handling",
+      "description": "Model output consumed without validation triggers downstream harm.",
+      "matchers": {
+        "tags": ["output_not_sanitized", "unsafe_rendering", "tool_output_trust"],
+        "detectors": ["output_validation_gap", "rendering_sink_audit"]
+      },
+      "mitigations": [
+        "Treat LLM responses as untrusted and sanitize before execution or rendering.",
+        "Apply schema validation and enforce allow-lists for tool calls.",
+        "Log and review outputs used in automated workflows."
+      ]
+    },
+    {
+      "id": "LLM03",
+      "name": "Training Data Poisoning",
+      "description": "Compromised training or fine-tuning data introduces malicious behavior.",
+      "matchers": {
+        "tags": ["training_data_untrusted", "dataset_poisoning", "weak_dataset_governance"],
+        "detectors": ["dataset_integrity_scanner"]
+      },
+      "mitigations": [
+        "Validate provenance and integrity of all training and fine-tuning datasets.",
+        "Use differential validation/evals to detect drift or malicious patterns.",
+        "Restrict who can upload or modify datasets."
+      ]
+    },
+    {
+      "id": "LLM04",
+      "name": "Model Denial of Service",
+      "description": "Excessive or crafted requests degrade model availability or latency.",
+      "matchers": {
+        "tags": ["resource_exhaustion", "rate_limit_bypass", "deep_chain_execution"],
+        "detectors": ["dos_simulation", "load_anomaly"]
+      },
+      "mitigations": [
+        "Rate limit user requests and enforce budget policies for tool chains.",
+        "Detect and throttle abnormal agent loops or recursion.",
+        "Provision autoscaling and circuit breakers for critical paths."
+      ]
+    },
+    {
+      "id": "LLM05",
+      "name": "Supply Chain Vulnerabilities",
+      "description": "Dependencies or plugins with known vulnerabilities compromise the system.",
+      "matchers": {
+        "tags": ["dependency_cve", "package_outdated", "tool_vulnerability"],
+        "detectors": ["osv_scanner", "pip_audit", "sbom_vuln_mapper"]
+      },
+      "mitigations": [
+        "Continuously scan dependencies and enforce patch SLAs.",
+        "Pin plugin and tool versions with verified checksums.",
+        "Review third-party integration permissions before deployment."
+      ]
+    },
+    {
+      "id": "LLM06",
+      "name": "Sensitive Information Disclosure",
+      "description": "Model or prompt leaks secrets, personal data, or regulated records.",
+      "matchers": {
+        "tags": ["secret_leak", "pii_exposure", "prompt_leakage"],
+        "detectors": ["pii_scanner", "secret_scanner", "prompt_leak_check"]
+      },
+      "mitigations": [
+        "Mask or redact sensitive data prior to prompt injection.",
+        "Enable output classifiers for sensitive topics and secrets.",
+        "Implement data retention limits and secure storage."
+      ]
+    },
+    {
+      "id": "LLM07",
+      "name": "Insecure Plugin Design",
+      "description": "Plugins or tools expose insecure interfaces leveraged by the model.",
+      "matchers": {
+        "tags": ["plugin_insecure", "tool_auth_missing", "callback_trust_gap"],
+        "detectors": ["plugin_contract_audit", "tool_surface_review"]
+      },
+      "mitigations": [
+        "Harden plugin authentication and authorization contracts.",
+        "Restrict plugin capabilities to least privilege and sandbox IO.",
+        "Review plugin schemas for injection or escalation paths."
+      ]
+    },
+    {
+      "id": "LLM08",
+      "name": "Excessive Agency",
+      "description": "Agent granted overly broad permissions to act without guardrails.",
+      "matchers": {
+        "tags": ["tool_overprivileged", "autonomous_chain", "unsafe_action_radius"],
+        "detectors": ["permission_diff", "agency_scope_scan"]
+      },
+      "mitigations": [
+        "Limit autonomous actions to audited, low-impact operations.",
+        "Add confirmation and human-in-the-loop checkpoints.",
+        "Continuously evaluate agent goals versus allowed policies."
+      ]
+    },
+    {
+      "id": "LLM09",
+      "name": "Overreliance",
+      "description": "System or operators trust LLM output without adequate verification.",
+      "matchers": {
+        "tags": ["lack_of_grounding", "no_feedback_loop", "hallucination_risk"],
+        "detectors": ["eval_coverage_gap", "hallucination_probe"]
+      },
+      "mitigations": [
+        "Introduce automated cross-checks or retrieval augmentation for facts.",
+        "Track eval coverage and fail open when guardrails degrade.",
+        "Educate operators on residual risk and verification steps."
+      ]
+    },
+    {
+      "id": "LLM10",
+      "name": "Model Theft",
+      "description": "Attackers steal model weights, prompts, or intellectual property.",
+      "matchers": {
+        "tags": ["model_exfiltration", "prompt_dump", "artifact_leak"],
+        "detectors": ["model_exfiltration_monitor", "artifact_access_anomaly"]
+      },
+      "mitigations": [
+        "Encrypt and access-control model artifacts and prompt stores.",
+        "Monitor for anomalous downloads or mass prompt access.",
+        "Apply watermarking and canary prompts to detect leaks."
+      ]
+    }
+  ]
+}

--- a/op_observe/agentic_security/loader.py
+++ b/op_observe/agentic_security/loader.py
@@ -1,0 +1,128 @@
+"""Loading helpers for versioned OWASP mapping tables."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from functools import lru_cache
+from importlib import resources
+from typing import Dict, Iterable, Tuple
+
+from .models import Category, CategoryMatcher, MappingTable
+
+_DATA_PACKAGE = "op_observe.agentic_security.data"
+_LLM_NAMESPACE = "owasp_llm_top10"
+_AGENTIC_NAMESPACE = "owasp_agentic_ai"
+
+
+def _version_sort_key(version: str) -> Tuple[int, ...]:
+    parts: list[int] = []
+    for element in version.replace("-", ".").split("."):
+        if element.isdigit():
+            parts.append(int(element))
+        else:
+            # Fallback for alphanumeric segments; use their ordinal values.
+            parts.extend(ord(ch) for ch in element)
+    return tuple(parts)
+
+
+def _iter_version_files(namespace: str) -> Iterable[resources.abc.Traversable]:
+    package = f"{_DATA_PACKAGE}.{namespace}"
+    data_path = resources.files(package)
+    for resource in data_path.iterdir():
+        if resource.name.endswith(".json"):
+            yield resource
+
+
+@lru_cache(maxsize=None)
+def _available_versions(namespace: str) -> Dict[str, str]:
+    versions: Dict[str, str] = {}
+    for resource in _iter_version_files(namespace):
+        with resource.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        version = str(payload["version"])
+        versions[version] = resource.name
+    return versions
+
+
+def list_llm_top10_versions() -> Tuple[str, ...]:
+    """Return the available versions for the OWASP LLM Top-10 table."""
+    versions = sorted(_available_versions(_LLM_NAMESPACE), key=_version_sort_key)
+    return tuple(versions)
+
+
+def list_agentic_ai_versions() -> Tuple[str, ...]:
+    """Return the available versions for the OWASP Agentic-AI table."""
+    versions = sorted(_available_versions(_AGENTIC_NAMESPACE), key=_version_sort_key)
+    return tuple(versions)
+
+
+def _resolve_version(namespace: str, requested: str | None) -> Tuple[str, str]:
+    available = _available_versions(namespace)
+    if not available:
+        raise ValueError(f"No mapping tables available for namespace '{namespace}'")
+    if requested is None:
+        version = sorted(available, key=_version_sort_key)[-1]
+    else:
+        version = requested
+    try:
+        filename = available[version]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(
+            f"Unknown version '{version}' for namespace '{namespace}'."
+        ) from exc
+    return version, filename
+
+
+@lru_cache(maxsize=None)
+def _load_mapping(namespace: str, version: str) -> MappingTable:
+    _, filename = _resolve_version(namespace, version)
+    package = f"{_DATA_PACKAGE}.{namespace}"
+    resource = resources.files(package).joinpath(filename)
+    with resource.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    published = date.fromisoformat(payload["published"])
+    scheme = payload["scheme"]
+    resolved_version = payload["version"]
+
+    categories = []
+    index: Dict[str, Category] = {}
+    for raw in payload["categories"]:
+        matchers = CategoryMatcher(
+            detectors=tuple(raw.get("matchers", {}).get("detectors", ())),
+            tags=tuple(raw.get("matchers", {}).get("tags", ())),
+        )
+        category = Category(
+            table_scheme=scheme,
+            table_version=resolved_version,
+            id=raw["id"],
+            name=raw["name"],
+            description=raw["description"],
+            matchers=matchers,
+            mitigations=tuple(raw.get("mitigations", ())),
+            references=tuple(raw.get("references", ())),
+        )
+        categories.append(category)
+        index[category.id] = category
+
+    return MappingTable(
+        scheme=scheme,
+        version=resolved_version,
+        published=published,
+        source=payload["source"],
+        categories=tuple(categories),
+        _category_index=index,
+    )
+
+
+def get_llm_top10_mapping(version: str | None = None) -> MappingTable:
+    """Load the OWASP LLM Top-10 mapping table."""
+    resolved, _ = _resolve_version(_LLM_NAMESPACE, version)
+    return _load_mapping(_LLM_NAMESPACE, resolved)
+
+
+def get_agentic_ai_mapping(version: str | None = None) -> MappingTable:
+    """Load the OWASP Agentic-AI mapping table."""
+    resolved, _ = _resolve_version(_AGENTIC_NAMESPACE, version)
+    return _load_mapping(_AGENTIC_NAMESPACE, resolved)

--- a/op_observe/agentic_security/mapper.py
+++ b/op_observe/agentic_security/mapper.py
@@ -1,0 +1,43 @@
+"""Map radar findings to OWASP categories."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .loader import get_agentic_ai_mapping, get_llm_top10_mapping
+from .models import Category, FindingMapping, MappingTable, RadarFinding
+
+
+def _match_categories(finding: RadarFinding, table: MappingTable) -> tuple[Category, ...]:
+    matches: list[Category] = []
+    for category in table:
+        if category.matchers.matches(finding):
+            matches.append(category)
+    return tuple(matches)
+
+
+def map_finding_to_tables(
+    finding: RadarFinding,
+    *,
+    llm_mapping: MappingTable | None = None,
+    agentic_mapping: MappingTable | None = None,
+    extra_tables: Sequence[MappingTable] | None = None,
+) -> FindingMapping:
+    """Return the mapping for a finding against the available OWASP tables."""
+
+    tables = []
+    if llm_mapping is None:
+        llm_mapping = get_llm_top10_mapping()
+    if agentic_mapping is None:
+        agentic_mapping = get_agentic_ai_mapping()
+
+    tables.extend(table for table in (llm_mapping, agentic_mapping) if table is not None)
+    if extra_tables:
+        tables.extend(extra_tables)
+
+    matches: dict[str, tuple[Category, ...]] = {}
+    for table in tables:
+        matched = _match_categories(finding, table)
+        if matched:
+            matches[table.scheme] = matched
+    return FindingMapping(finding=finding, matches=matches)

--- a/op_observe/agentic_security/mitigations.py
+++ b/op_observe/agentic_security/mitigations.py
@@ -1,0 +1,45 @@
+"""Mitigation checklist helpers for mapped findings."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .models import FindingMapping, MitigationChecklistEntry
+
+
+def generate_mitigation_checklist(
+    mappings: Iterable[FindingMapping],
+) -> tuple[MitigationChecklistEntry, ...]:
+    """Aggregate mitigations across mappings for reporting and remediation."""
+
+    aggregated: dict[str, dict[str, object]] = {}
+
+    for mapping in mappings:
+        for category in mapping.all_categories():
+            key = category.reference
+            bucket = aggregated.setdefault(
+                key,
+                {
+                    "category": category,
+                    "finding_ids": set(),
+                },
+            )
+            bucket["finding_ids"].add(mapping.finding.id)
+
+    def _sort_key(entry: dict[str, object]) -> tuple[str, str]:
+        category = entry["category"]
+        return (category.table_scheme, category.id)
+
+    checklist: list[MitigationChecklistEntry] = []
+    for entry in sorted(aggregated.values(), key=_sort_key):
+        category = entry["category"]
+        finding_ids = tuple(sorted(entry["finding_ids"]))
+        checklist.append(
+            MitigationChecklistEntry(
+                category=category,
+                finding_ids=finding_ids,
+                mitigations=category.mitigations,
+            )
+        )
+
+    return tuple(checklist)

--- a/op_observe/agentic_security/models.py
+++ b/op_observe/agentic_security/models.py
@@ -1,0 +1,148 @@
+"""Data models for OWASP mapping tables and radar findings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from types import MappingProxyType
+from typing import Mapping, Sequence, Tuple
+
+
+def _normalize_sequence(values: Sequence[str]) -> Tuple[str, ...]:
+    """Return a tuple of lower-cased unique values preserving input order."""
+    seen = {}
+    for value in values:
+        normalized = value.strip().lower()
+        if normalized and normalized not in seen:
+            seen[normalized] = None
+    return tuple(seen.keys())
+
+
+@dataclass(frozen=True)
+class CategoryMatcher:
+    """Matching rules for assigning findings to OWASP categories."""
+
+    detectors: Tuple[str, ...] = field(default_factory=tuple)
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "detectors", _normalize_sequence(self.detectors))
+        object.__setattr__(self, "tags", _normalize_sequence(self.tags))
+
+    def matches(self, finding: "RadarFinding") -> bool:
+        """Return ``True`` when the matcher covers the provided finding."""
+        if self.detectors and finding.detector in self.detectors:
+            return True
+        if self.tags and finding.tags_set.intersection(self.tags):
+            return True
+        return False
+
+
+@dataclass(frozen=True)
+class Category:
+    """A single OWASP category entry."""
+
+    table_scheme: str
+    table_version: str
+    id: str
+    name: str
+    description: str
+    matchers: CategoryMatcher
+    mitigations: Tuple[str, ...]
+    references: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "table_scheme", self.table_scheme)
+        object.__setattr__(self, "table_version", self.table_version)
+        object.__setattr__(self, "id", self.id.strip())
+        object.__setattr__(self, "name", self.name.strip())
+        object.__setattr__(self, "description", self.description.strip())
+        object.__setattr__(self, "mitigations", tuple(m.strip() for m in self.mitigations if m.strip()))
+        object.__setattr__(self, "references", tuple(r.strip() for r in self.references if r.strip()))
+
+    @property
+    def reference(self) -> str:
+        """Return a stable reference combining scheme and identifier."""
+        return f"{self.table_scheme}:{self.id}"
+
+
+@dataclass(frozen=True)
+class MappingTable:
+    """A versioned mapping table loaded from JSON resources."""
+
+    scheme: str
+    version: str
+    published: date
+    source: str
+    categories: Tuple[Category, ...]
+    _category_index: Mapping[str, Category] = field(repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "scheme", self.scheme)
+        object.__setattr__(self, "version", self.version)
+        object.__setattr__(self, "source", self.source)
+        object.__setattr__(self, "categories", tuple(self.categories))
+        object.__setattr__(self, "_category_index", MappingProxyType(dict(self._category_index)))
+
+    def category(self, category_id: str) -> Category:
+        return self._category_index[category_id]
+
+    def __iter__(self):
+        return iter(self.categories)
+
+
+@dataclass(frozen=True)
+class RadarFinding:
+    """Security finding emitted by the radar detector framework."""
+
+    id: str
+    detector: str
+    tags: Sequence[str] = field(default_factory=tuple)
+    severity: str = "medium"
+    description: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", self.id)
+        object.__setattr__(self, "detector", self.detector.strip().lower())
+        object.__setattr__(self, "severity", self.severity.strip().lower())
+        object.__setattr__(self, "tags", _normalize_sequence(self.tags))
+        if self.metadata is None:
+            metadata: Mapping[str, object] = {}
+        else:
+            metadata = dict(self.metadata)
+        object.__setattr__(self, "metadata", MappingProxyType(metadata))
+
+    @property
+    def tags_set(self) -> frozenset[str]:
+        return frozenset(self.tags)
+
+
+@dataclass(frozen=True)
+class FindingMapping:
+    """Mapping result for a single finding across multiple tables."""
+
+    finding: RadarFinding
+    matches: Mapping[str, Tuple[Category, ...]]
+
+    def __post_init__(self) -> None:
+        normalized = {scheme: tuple(categories) for scheme, categories in self.matches.items()}
+        object.__setattr__(self, "matches", MappingProxyType(normalized))
+
+    def categories_for_scheme(self, scheme: str) -> Tuple[Category, ...]:
+        return self.matches.get(scheme, ())
+
+    def all_categories(self) -> Tuple[Category, ...]:
+        result: list[Category] = []
+        for categories in self.matches.values():
+            result.extend(categories)
+        return tuple(result)
+
+
+@dataclass(frozen=True)
+class MitigationChecklistEntry:
+    """Aggregated mitigation entry for reporting."""
+
+    category: Category
+    finding_ids: Tuple[str, ...]
+    mitigations: Tuple[str, ...]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,30 @@
+from datetime import date
+
+from op_observe.agentic_security.loader import (
+    get_agentic_ai_mapping,
+    get_llm_top10_mapping,
+    list_agentic_ai_versions,
+    list_llm_top10_versions,
+)
+
+
+def test_llm_top10_mapping_loads_latest_version():
+    versions = list_llm_top10_versions()
+    assert "2024.1" in versions
+    table = get_llm_top10_mapping()
+    assert table.version == "2024.1"
+    assert table.scheme == "OWASP-LLM"
+    assert isinstance(table.published, date)
+    prompt_injection = table.category("LLM01")
+    assert "Prompt Injection" in prompt_injection.name
+
+
+def test_agentic_ai_mapping_loads_latest_version():
+    versions = list_agentic_ai_versions()
+    assert "2024.1" in versions
+    table = get_agentic_ai_mapping()
+    assert table.version == "2024.1"
+    assert table.scheme == "OWASP-Agentic"
+    assert isinstance(table.published, date)
+    toolchain_abuse = table.category("AA02")
+    assert "Toolchain" in toolchain_abuse.name

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,0 +1,74 @@
+from op_observe.agentic_security import (
+    generate_mitigation_checklist,
+    map_finding_to_tables,
+)
+from op_observe.agentic_security.models import RadarFinding
+
+
+def test_map_prompt_injection_finding():
+    finding = RadarFinding(
+        id="F-001",
+        detector="prompt_injection_scanner",
+        tags=("Prompt_Injection",),
+    )
+    mapping = map_finding_to_tables(finding)
+    llm_matches = mapping.categories_for_scheme("OWASP-LLM")
+    assert {category.id for category in llm_matches} == {"LLM01"}
+    assert mapping.categories_for_scheme("OWASP-Agentic") == ()
+
+
+def test_map_agentic_tool_abuse_by_detector_only():
+    finding = RadarFinding(
+        id="F-002",
+        detector="tool_abuse_probe",
+        tags=(),
+    )
+    mapping = map_finding_to_tables(finding)
+    agentic_matches = mapping.categories_for_scheme("OWASP-Agentic")
+    assert {category.id for category in agentic_matches} == {"AA02"}
+
+
+def test_map_dependency_vulnerability_by_detector():
+    finding = RadarFinding(
+        id="F-003",
+        detector="osv_scanner",
+        tags=(),
+    )
+    mapping = map_finding_to_tables(finding)
+    llm_matches = mapping.categories_for_scheme("OWASP-LLM")
+    assert {category.id for category in llm_matches} == {"LLM05"}
+
+
+
+def test_unmapped_finding_returns_empty_categories():
+    finding = RadarFinding(
+        id="F-006",
+        detector="custom_detector",
+        tags=("unexpected",),
+    )
+    mapping = map_finding_to_tables(finding)
+    assert mapping.all_categories() == ()
+
+
+def test_generate_mitigation_checklist_deduplicates_categories():
+    finding_one = RadarFinding(
+        id="F-004",
+        detector="osv_scanner",
+        tags=("dependency_cve",),
+    )
+    finding_two = RadarFinding(
+        id="F-005",
+        detector="pip_audit",
+        tags=("package_outdated",),
+    )
+
+    mapping_one = map_finding_to_tables(finding_one)
+    mapping_two = map_finding_to_tables(finding_two)
+
+    checklist = generate_mitigation_checklist([mapping_one, mapping_two])
+    assert checklist, "Expected at least one mitigation entry"
+    supply_chain_entry = next(
+        entry for entry in checklist if entry.category.id == "LLM05"
+    )
+    assert supply_chain_entry.finding_ids == ("F-004", "F-005")
+    assert "Continuously scan dependencies" in supply_chain_entry.mitigations[0]


### PR DESCRIPTION
## Summary
- add versioned OWASP LLM Top-10 and Agentic-AI mapping tables with matchers and mitigations
- implement loaders, mapping helpers, and mitigation checklist aggregation for radar findings
- cover functionality with pytest-based unit tests and path bootstrap for package imports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b7959a64832bac10861d3599dcc7