### PR TITLE
Add asynchronous cross-encoder reranking pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/benchmarks/reranker_benchmark.py
+++ b/benchmarks/reranker_benchmark.py
@@ -1,0 +1,49 @@
+"""Micro-benchmark for the asynchronous cross-encoder reranker."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from op_observe.retrieval import (
+    Document,
+    InMemoryVectorStore,
+    SemanticSearchPipeline,
+    SimpleCrossEncoderReranker,
+)
+
+
+async def run_benchmark(iterations: int = 200) -> None:
+    documents = [
+        Document(doc_id=f"doc-{idx}", content=f"Agentic security posture iteration {idx}")
+        for idx in range(10)
+    ]
+    store = InMemoryVectorStore(documents)
+    reranker = SimpleCrossEncoderReranker()
+    pipeline = SemanticSearchPipeline(store, reranker=reranker)
+    query = "agentic security posture"
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        response = await pipeline.search(query, top_k=5, rerank=True)
+        await response.get_results()
+    rerank_total = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        response = await pipeline.search(query, top_k=5, rerank=False)
+        await response.get_results()
+    baseline_total = time.perf_counter() - start
+
+    print("Iterations:", iterations)
+    print(f"With rerank total: {rerank_total:.4f}s (avg {rerank_total / iterations:.6f}s)")
+    print(f"Baseline total: {baseline_total:.4f}s (avg {baseline_total / iterations:.6f}s)")
+    print(f"Average overhead per query: {(rerank_total - baseline_total) / iterations:.6f}s")
+
+
+def main() -> None:
+    asyncio.run(run_benchmark())
+
+
+if __name__ == "__main__":
+    main()

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,0 +1,3 @@
+"""OP-Observe core package."""
+
+__all__ = ["retrieval"]

--- a/op_observe/retrieval/__init__.py
+++ b/op_observe/retrieval/__init__.py
@@ -1,0 +1,17 @@
+"""Retrieval pipeline components for OP-Observe."""
+
+from .models import Document, SearchHit
+from .pipeline import SearchResponse, SemanticSearchPipeline
+from .rerankers import CrossEncoderReranker, SimpleCrossEncoderReranker
+from .vector_store import InMemoryVectorStore, VectorStore
+
+__all__ = [
+    "Document",
+    "SearchHit",
+    "SearchResponse",
+    "SemanticSearchPipeline",
+    "CrossEncoderReranker",
+    "SimpleCrossEncoderReranker",
+    "InMemoryVectorStore",
+    "VectorStore",
+]

--- a/op_observe/retrieval/models.py
+++ b/op_observe/retrieval/models.py
@@ -1,0 +1,50 @@
+"""Data models used across the retrieval pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+
+@dataclass(frozen=True)
+class Document:
+    """Container representing a retrievable document."""
+
+    doc_id: str
+    content: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SearchHit:
+    """Represents a scored document returned by the retrieval pipeline."""
+
+    document: Document
+    score: float
+    rank: int
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def with_score(
+        self,
+        *,
+        score: float,
+        rank: int,
+        score_source: str,
+        extra_metadata: Optional[Dict[str, Any]] = None,
+    ) -> "SearchHit":
+        """Return a copy of the hit updated with a new score and rank.
+
+        The original metadata is preserved and augmented with baseline score
+        bookkeeping to make provenance explicit when a reranker adjusts the
+        ordering.
+        """
+
+        merged: Dict[str, Any] = dict(self.metadata)
+        merged.setdefault("baseline_score", self.score)
+        merged["score_source"] = score_source
+        if extra_metadata:
+            merged.update(extra_metadata)
+        return SearchHit(document=self.document, score=score, rank=rank, metadata=merged)
+
+
+__all__ = ["Document", "SearchHit"]

--- a/op_observe/retrieval/pipeline.py
+++ b/op_observe/retrieval/pipeline.py
@@ -1,0 +1,119 @@
+"""Retrieval pipeline with optional cross-encoder reranking."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import List, Optional, Sequence
+
+from .models import SearchHit
+from .rerankers import CrossEncoderReranker
+from .vector_store import VectorStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SearchResponse:
+    """Container returned by :class:`SemanticSearchPipeline`.
+
+    The response exposes both the initial ANN ranking and the asynchronously
+    computed reranked results (if enabled).  Consumers can read the initial hits
+    immediately via :meth:`results_nowait` without waiting for the cross-encoder
+    to finish.
+    """
+
+    def __init__(self, query: str, initial_hits: Sequence[SearchHit]) -> None:
+        self.query = query
+        self.initial_hits = tuple(initial_hits)
+        self._rerank_task: Optional[asyncio.Task[List[SearchHit]]] = None
+        self._reranked_hits: Optional[List[SearchHit]] = None
+        self._rerank_failed = False
+        self._rerank_exception: Optional[BaseException] = None
+
+    def attach_rerank_task(self, task: asyncio.Task[List[SearchHit]]) -> None:
+        if self._rerank_task is not None:
+            raise RuntimeError("Rerank task already attached")
+        self._rerank_task = task
+        task.add_done_callback(self._store_rerank_result)
+
+    def _store_rerank_result(self, task: asyncio.Task[List[SearchHit]]) -> None:
+        try:
+            self._reranked_hits = task.result()
+            self._rerank_failed = False
+            self._rerank_exception = None
+        except Exception as exc:  # noqa: BLE001 - surface the failure downstream
+            LOGGER.warning("Cross-encoder rerank failed; using ANN order", exc_info=exc)
+            self._reranked_hits = list(self.initial_hits)
+            self._rerank_failed = True
+            self._rerank_exception = exc
+
+    def results_nowait(self) -> Sequence[SearchHit]:
+        """Return whichever set of results is currently available."""
+
+        if self._reranked_hits is not None:
+            return tuple(self._reranked_hits)
+        return self.initial_hits
+
+    async def get_results(self) -> Sequence[SearchHit]:
+        """Await the reranker if present and return the best available results."""
+
+        if self._rerank_task and not self._rerank_task.done():
+            try:
+                await asyncio.shield(self._rerank_task)
+            except Exception:  # rerank failure already logged in callback
+                return self.initial_hits
+        return self.results_nowait()
+
+    def rerank_ready(self) -> bool:
+        """Whether the reranked results are ready to be consumed."""
+
+        if not self._rerank_task:
+            return True
+        return self._rerank_task.done()
+
+    @property
+    def rerank_failed(self) -> bool:
+        return self._rerank_failed
+
+    @property
+    def rerank_exception(self) -> Optional[BaseException]:
+        return self._rerank_exception
+
+    @property
+    def has_async_rerank(self) -> bool:
+        return self._rerank_task is not None
+
+
+class SemanticSearchPipeline:
+    """Composes vector search with an optional asynchronous reranker."""
+
+    def __init__(self, vector_store: VectorStore, reranker: Optional[CrossEncoderReranker] = None) -> None:
+        self._vector_store = vector_store
+        self._reranker = reranker
+
+    async def search(self, query: str, *, top_k: int = 5, rerank: bool = True) -> SearchResponse:
+        """Retrieve the top results for ``query``.
+
+        When reranking is enabled and a reranker is configured, the heavy scoring
+        runs in the background.  Callers can inspect the immediate results to stay
+        within tight latency budgets and optionally await :meth:`SearchResponse.get_results`
+        to obtain the refined ordering.
+        """
+
+        initial_hits = self._vector_store.search(query, top_k)
+        response = SearchResponse(query, initial_hits)
+        if rerank and self._reranker and initial_hits:
+            task = asyncio.create_task(self._run_rerank(query, initial_hits))
+            response.attach_rerank_task(task)
+        return response
+
+    async def _run_rerank(self, query: str, hits: Sequence[SearchHit]) -> List[SearchHit]:
+        if not self._reranker:
+            return list(hits)
+        reranked = await self._reranker.rerank(query, hits)
+        if not reranked:
+            return list(hits)
+        return reranked
+
+
+__all__ = ["SearchResponse", "SemanticSearchPipeline"]

--- a/op_observe/retrieval/rerankers.py
+++ b/op_observe/retrieval/rerankers.py
@@ -1,0 +1,97 @@
+"""Cross-encoder rerankers for semantic search."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from typing import List, Protocol, Sequence
+
+from .models import SearchHit
+
+_TOKEN_PATTERN = re.compile(r"[\w']+")
+
+
+class CrossEncoderReranker(Protocol):
+    """Protocol implemented by asynchronous rerankers."""
+
+    async def rerank(self, query: str, hits: Sequence[SearchHit]) -> List[SearchHit]:
+        """Return the reranked hits."""
+
+
+class SimpleCrossEncoderReranker:
+    """Deterministic reranker that simulates a cross-encoder.
+
+    The implementation is intentionally lightweight so that it can run inside the
+    evaluation environment without pulling heavy model dependencies.  It
+    emphasises contiguous phrase matches and token overlap to produce a refined
+    ordering of the candidates produced by the vector store.  To keep the
+    reranking path out of the p95 latency budget, the actual scoring is executed
+    in a worker thread via :func:`asyncio.to_thread`.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_weight: float = 0.1,
+        overlap_weight: float = 0.3,
+        phrase_weight: float = 1.0,
+        latency: float = 0.0,
+    ) -> None:
+        self._base_weight = base_weight
+        self._overlap_weight = overlap_weight
+        self._phrase_weight = phrase_weight
+        self._latency = latency
+
+    async def rerank(self, query: str, hits: Sequence[SearchHit]) -> List[SearchHit]:
+        if not hits:
+            return []
+        return await asyncio.to_thread(self._rerank_sync, query, tuple(hits))
+
+    def _rerank_sync(self, query: str, hits: Sequence[SearchHit]) -> List[SearchHit]:
+        if self._latency > 0:
+            time.sleep(self._latency)
+        query_tokens = self._tokenize(query)
+        query_tuple = tuple(query_tokens)
+        query_set = set(query_tokens)
+        scored: List[tuple[float, SearchHit, dict[str, int]]] = []
+        for hit in hits:
+            doc_tokens = self._tokenize(hit.document.content)
+            overlap = sum(1 for token in doc_tokens if token in query_set)
+            phrase_hits = self._count_phrase(query_tuple, doc_tokens)
+            score = (
+                self._base_weight * hit.score
+                + self._overlap_weight * overlap
+                + self._phrase_weight * phrase_hits
+            )
+            scored.append((score, hit, {"rerank_overlap": overlap, "rerank_phrase_hits": phrase_hits}))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        reranked: List[SearchHit] = []
+        for rank, (score, hit, metadata) in enumerate(scored, start=1):
+            reranked.append(
+                hit.with_score(
+                    score=score,
+                    rank=rank,
+                    score_source="cross_encoder",
+                    extra_metadata=metadata,
+                )
+            )
+        return reranked
+
+    @staticmethod
+    def _tokenize(text: str) -> List[str]:
+        return _TOKEN_PATTERN.findall(text.lower())
+
+    @staticmethod
+    def _count_phrase(query_tokens: Sequence[str], doc_tokens: Sequence[str]) -> int:
+        if len(query_tokens) < 2 or len(doc_tokens) < len(query_tokens):
+            return 0
+        window = len(query_tokens)
+        hits = 0
+        for index in range(len(doc_tokens) - window + 1):
+            if tuple(doc_tokens[index : index + window]) == tuple(query_tokens):
+                hits += 1
+        return hits
+
+
+__all__ = ["CrossEncoderReranker", "SimpleCrossEncoderReranker"]

--- a/op_observe/retrieval/vector_store.py
+++ b/op_observe/retrieval/vector_store.py
@@ -1,0 +1,72 @@
+"""Lightweight in-memory vector store used for tests and demos."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Iterable, List, Protocol, Tuple
+
+from .models import Document, SearchHit
+
+_TOKEN_PATTERN = re.compile(r"[\w']+")
+
+
+class VectorStore(Protocol):
+    """Protocol describing the retrieval operations expected by the pipeline."""
+
+    def search(self, query: str, top_k: int) -> List[SearchHit]:
+        """Return the top-k hits for the query."""
+
+
+class InMemoryVectorStore:
+    """Tiny vector store backed by pre-computed token frequency vectors.
+
+    The goal is to provide a deterministic, dependency-free store that exercises
+    the retrieval pipeline.  The implementation intentionally keeps the scoring
+    simple (raw dot product without normalization) to create scenarios where the
+    reranker can produce a different ordering.
+    """
+
+    def __init__(self, documents: Iterable[Document] | None = None) -> None:
+        self._entries: List[Tuple[Document, Counter[str]]] = []
+        if documents is not None:
+            for doc in documents:
+                self.add_document(doc)
+
+    def add_document(self, document: Document) -> None:
+        """Store the document and cache its token counts."""
+
+        self._entries.append((document, self._vectorize(document.content)))
+
+    def search(self, query: str, top_k: int) -> List[SearchHit]:
+        vector = self._vectorize(query)
+        scored: List[Tuple[float, Document]] = []
+        for document, doc_vector in self._entries:
+            score = self._dot(vector, doc_vector)
+            scored.append((score, document))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        hits: List[SearchHit] = []
+        for rank, (score, document) in enumerate(scored[:top_k], start=1):
+            hits.append(
+                SearchHit(
+                    document=document,
+                    score=score,
+                    rank=rank,
+                    metadata={"score_source": "vector_store"},
+                )
+            )
+        return hits
+
+    @staticmethod
+    def _vectorize(text: str) -> Counter[str]:
+        tokens = _TOKEN_PATTERN.findall(text.lower())
+        return Counter(tokens)
+
+    @staticmethod
+    def _dot(query: Counter[str], document: Counter[str]) -> float:
+        if not query or not document:
+            return 0.0
+        return float(sum(query[token] * document[token] for token in query))
+
+
+__all__ = ["VectorStore", "InMemoryVectorStore"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for ensuring package imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,114 @@
+import asyncio
+import time
+from typing import Sequence
+
+from op_observe.retrieval import (
+    Document,
+    InMemoryVectorStore,
+    SearchHit,
+    SemanticSearchPipeline,
+    SimpleCrossEncoderReranker,
+)
+
+
+def test_cross_encoder_reranks_for_phrase_matches() -> None:
+    async def _run() -> None:
+        documents = [
+            Document(
+                doc_id="dense-security",
+                content="Security security security practices with a nod to agentic systems",
+            ),
+            Document(
+                doc_id="agentic-security",
+                content="Agentic security posture management playbook",
+            ),
+            Document(doc_id="observability", content="Observability metrics and tracing deep dive"),
+        ]
+        store = InMemoryVectorStore(documents)
+        pipeline = SemanticSearchPipeline(
+            store,
+            reranker=SimpleCrossEncoderReranker(base_weight=0.1, overlap_weight=0.3, phrase_weight=1.4),
+        )
+
+        response = await pipeline.search("agentic security", top_k=3, rerank=True)
+        initial_ids = [hit.document.doc_id for hit in response.initial_hits]
+        assert initial_ids[0] == "dense-security"
+
+        reranked_results = await response.get_results()
+        reranked_ids = [hit.document.doc_id for hit in reranked_results]
+        assert reranked_ids[0] == "agentic-security"
+        assert reranked_results[0].metadata["score_source"] == "cross_encoder"
+        assert "baseline_score" in reranked_results[0].metadata
+
+    asyncio.run(_run())
+
+
+def test_async_rerank_does_not_block_initial_results() -> None:
+    async def _run() -> None:
+        documents = [
+            Document(doc_id="a", content="Security security agentic"),
+            Document(doc_id="b", content="Agentic security posture"),
+        ]
+        store = InMemoryVectorStore(documents)
+        latency = 0.1
+        reranker = SimpleCrossEncoderReranker(latency=latency)
+        pipeline = SemanticSearchPipeline(store, reranker=reranker)
+
+        start = time.perf_counter()
+        response = await pipeline.search("agentic security", top_k=2, rerank=True)
+        elapsed = time.perf_counter() - start
+
+        # The heavy reranker sleeps for ``latency`` seconds; returning faster shows the
+        # operation was launched asynchronously.
+        assert elapsed < latency
+        assert response.has_async_rerank
+
+        initial_now = response.results_nowait()
+        assert list(initial_now) == list(response.initial_hits)
+
+        final_results = await response.get_results()
+        assert len(final_results) == 2
+
+    asyncio.run(_run())
+
+
+def test_pipeline_respects_rerank_disabled_flag() -> None:
+    async def _run() -> None:
+        documents = [
+            Document(doc_id="a", content="Security security agentic"),
+            Document(doc_id="b", content="Agentic security posture"),
+        ]
+        store = InMemoryVectorStore(documents)
+        pipeline = SemanticSearchPipeline(store, reranker=SimpleCrossEncoderReranker())
+
+        response = await pipeline.search("agentic security", top_k=2, rerank=False)
+        assert not response.has_async_rerank
+
+        results = await response.get_results()
+        assert list(results) == list(response.initial_hits)
+
+    asyncio.run(_run())
+
+
+class FailingReranker(SimpleCrossEncoderReranker):
+    async def rerank(self, query: str, hits: Sequence[SearchHit]) -> Sequence[SearchHit]:
+        raise RuntimeError("boom")
+
+
+def test_rerank_failure_falls_back_to_ann() -> None:
+    async def _run() -> None:
+        documents = [
+            Document(doc_id="a", content="Security security agentic"),
+            Document(doc_id="b", content="Agentic security posture"),
+        ]
+        store = InMemoryVectorStore(documents)
+        pipeline = SemanticSearchPipeline(store, reranker=FailingReranker())
+
+        response = await pipeline.search("agentic security", top_k=2, rerank=True)
+        results = await response.get_results()
+
+        assert list(results) == list(response.initial_hits)
+        assert response.rerank_failed
+        assert isinstance(response.rerank_exception, RuntimeError)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a retrieval package with optional cross-encoder reranking and asynchronous refinement
- implement a lightweight in-memory vector store and cross-encoder heuristics with provenance metadata
- cover the new pipeline with unit tests and provide a simple benchmark script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b7901bf0832ba77c0da545483ec8