### PR TITLE
Add orchestrator integration harness and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+
+automation/

--- a/opobserve/__init__.py
+++ b/opobserve/__init__.py
@@ -1,0 +1,23 @@
+"""Integration-test utilities for the OP-Observe orchestrator demo."""
+
+from .agent import Document, Guardrails, InMemoryRetriever, LangGraphAgent, MCPServer, MockLLM, Tool
+from .orchestrator import CoreOrchestrator, CoreOrchestratorConfig, OrchestratorResult
+from .radar import RadarReport, RadarScanner
+from .telemetry import Span, TelemetryCollector
+
+__all__ = [
+    "CoreOrchestrator",
+    "CoreOrchestratorConfig",
+    "OrchestratorResult",
+    "Document",
+    "Guardrails",
+    "InMemoryRetriever",
+    "LangGraphAgent",
+    "MCPServer",
+    "MockLLM",
+    "Tool",
+    "RadarReport",
+    "RadarScanner",
+    "TelemetryCollector",
+    "Span",
+]

--- a/opobserve/agent.py
+++ b/opobserve/agent.py
@@ -1,0 +1,194 @@
+"""Simplified LangGraph-style agent primitives used in integration tests."""
+from __future__ import annotations
+
+import math
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+from .telemetry import TelemetryCollector
+
+
+@dataclass
+class Document:
+    doc_id: str
+    text: str
+    metadata: Dict[str, str]
+
+
+@dataclass
+class Tool:
+    name: str
+    version: str
+    source: str
+    description: str
+    permissions: Sequence[str] = field(default_factory=list)
+    risk_category: str = "low"
+
+
+@dataclass
+class MCPServer:
+    name: str
+    endpoint: str
+    capabilities: Sequence[str]
+    auth_mode: str
+
+
+class InMemoryRetriever:
+    """Vector-style retrieval over a small in-memory corpus."""
+
+    def __init__(self, documents: Iterable[Document], latency_ms: float = 75.0, top_k: int = 2) -> None:
+        self._documents = list(documents)
+        self.latency_ms = latency_ms
+        self.top_k = top_k
+
+    def retrieve(self, query: str, telemetry: TelemetryCollector) -> List[Document]:
+        with telemetry.span("retriever.vector_search", component="retrieval") as span:
+            # Simulate ANN lookup latency without external dependencies.
+            simulated_latency = max(self.latency_ms / 1000.0, 0.001)
+            time.sleep(simulated_latency)
+            scored = [
+                (self._similarity(query, doc.text), doc)
+                for doc in self._documents
+            ]
+            scored.sort(key=lambda pair: pair[0], reverse=True)
+            results = [doc for _, doc in scored[: self.top_k]]
+        telemetry.record_metric("search_latency_ms", span.span.duration_ms)
+        telemetry.record_metric("retrieved_documents", len(results))
+        telemetry.increment("retrieval_calls")
+        telemetry.record_log(
+            "retrieval.ok docs=%s latency=%.2fms" % (len(results), span.span.duration_ms)
+        )
+        return results
+
+    @staticmethod
+    def _similarity(query: str, text: str) -> float:
+        query_terms = set(query.lower().split())
+        text_terms = set(text.lower().split())
+        if not query_terms:
+            return 0.0
+        return len(query_terms.intersection(text_terms)) / math.sqrt(len(text_terms) or 1)
+
+
+class Guardrails:
+    """Very small rule-based guardrail implementation for demo purposes."""
+
+    def __init__(self, banned_keywords: Sequence[str]) -> None:
+        self.banned_keywords = [kw.lower() for kw in banned_keywords]
+
+    def validate(self, query: str, documents: Sequence[Document], telemetry: TelemetryCollector) -> Dict[str, object]:
+        with telemetry.span("guardrails.validation", component="guardrails") as span:
+            flagged: List[Document] = []
+            for doc in documents:
+                content = doc.text.lower()
+                if any(kw in content for kw in self.banned_keywords):
+                    flagged.append(doc)
+        telemetry.record_metric("guardrail_pass", 0 if flagged else 1)
+        telemetry.record_metric("guardrail_violations", len(flagged))
+        telemetry.record_metric("guardrail_latency_ms", span.span.duration_ms)
+        telemetry.record_log(
+            "guardrails.%s violations=%s latency=%.2fms"
+            % ("fail" if flagged else "pass", len(flagged), span.span.duration_ms)
+        )
+        return {"passed": not flagged, "flagged_documents": flagged}
+
+
+class MockLLM:
+    """Simulates an LLM call and generates deterministic output."""
+
+    def __init__(self, model_name: str = "demo-llm", latency_ms: float = 55.0) -> None:
+        self.model_name = model_name
+        self.latency_ms = latency_ms
+
+    def generate(self, query: str, documents: Sequence[Document], telemetry: TelemetryCollector) -> str:
+        with telemetry.span("llm.synthesize", component="llm", model=self.model_name) as span:
+            time.sleep(max(self.latency_ms / 1000.0, 0.001))
+            highlighted = " ".join(doc.text for doc in documents)
+            response = f"Answering '{query}' using context: {highlighted}".strip()
+        telemetry.record_metric("llm_latency_ms", span.span.duration_ms)
+        telemetry.record_metric("llm_tokens", len(response.split()))
+        telemetry.record_log(
+            "llm.generated model=%s tokens=%s latency=%.2fms"
+            % (self.model_name, len(response.split()), span.span.duration_ms)
+        )
+        return response
+
+
+@dataclass
+class AgentRunResult:
+    documents: Sequence[Document]
+    guardrail_result: Dict[str, object]
+    response: str
+
+
+class LangGraphAgent:
+    """Minimal LangGraph-like agent with retrieval, guardrails, and a mock LLM."""
+
+    def __init__(
+        self,
+        retriever: InMemoryRetriever,
+        guardrails: Guardrails,
+        llm: MockLLM,
+        tools: Sequence[Tool],
+        mcp_servers: Sequence[MCPServer],
+        telemetry: TelemetryCollector,
+    ) -> None:
+        self.retriever = retriever
+        self.guardrails = guardrails
+        self.llm = llm
+        self.tools = list(tools)
+        self.mcp_servers = list(mcp_servers)
+        self.telemetry = telemetry
+
+    def run(self, query: str) -> AgentRunResult:
+        self.telemetry.record_log("agent.start query=%s" % query)
+        documents = self.retriever.retrieve(query, self.telemetry)
+        guardrail_result = self.guardrails.validate(query, documents, self.telemetry)
+        response = self.llm.generate(query, documents, self.telemetry)
+        self.telemetry.record_log("agent.complete response_tokens=%s" % len(response.split()))
+        return AgentRunResult(documents=documents, guardrail_result=guardrail_result, response=response)
+
+    # ---- Radar helpers -------------------------------------------------
+    def workflow_graph(self) -> Dict[str, object]:
+        return {
+            "nodes": [
+                {"id": "retriever", "type": "retrieval", "description": "Vector search over demo corpus"},
+                {"id": "guardrails", "type": "guardrail", "description": "Keyword allow/block list"},
+                {"id": "llm", "type": "llm", "description": self.llm.model_name},
+            ],
+            "edges": [
+                {"source": "retriever", "target": "guardrails"},
+                {"source": "guardrails", "target": "llm"},
+            ],
+        }
+
+    def tool_inventory(self) -> List[Dict[str, object]]:
+        inventory: List[Dict[str, object]] = []
+        for tool in self.tools:
+            inventory.append(
+                {
+                    "name": tool.name,
+                    "version": tool.version,
+                    "source": tool.source,
+                    "description": tool.description,
+                    "permissions": list(tool.permissions),
+                    "risk_category": tool.risk_category,
+                }
+            )
+        return inventory
+
+    def mcp_inventory(self) -> List[Dict[str, object]]:
+        return [
+            {
+                "name": server.name,
+                "endpoint": server.endpoint,
+                "auth_mode": server.auth_mode,
+                "capabilities": list(server.capabilities),
+            }
+            for server in self.mcp_servers
+        ]
+
+    def trace_links(self, telemetry: TelemetryCollector) -> List[str]:
+        random.seed(42)
+        return [f"trace-{idx}-{int(span.duration_ms)}" for idx, span in enumerate(telemetry.spans)]

--- a/opobserve/orchestrator.py
+++ b/opobserve/orchestrator.py
@@ -1,0 +1,149 @@
+"""Core orchestrator wiring for integration tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .agent import (
+    Document,
+    Guardrails,
+    InMemoryRetriever,
+    LangGraphAgent,
+    MCPServer,
+    MockLLM,
+    Tool,
+)
+from .radar import RadarReport, RadarScanner
+from .telemetry import TelemetryCollector
+
+
+@dataclass
+class CoreOrchestratorConfig:
+    documents: List[Document]
+    banned_keywords: List[str]
+    tools: List[Tool]
+    mcp_servers: List[MCPServer]
+    retriever_latency_ms: float = 65.0
+    retriever_top_k: int = 2
+    llm_latency_ms: float = 55.0
+    llm_model: str = "demo-llm"
+    owasp_mapping: Optional[Dict[str, Dict[str, str]]] = None
+
+    @staticmethod
+    def demo() -> "CoreOrchestratorConfig":
+        return CoreOrchestratorConfig(
+            documents=[
+                Document(
+                    doc_id="doc-1",
+                    text="Observability platform with guardrails, vector search, and agentic radar.",
+                    metadata={"source": "kb"},
+                ),
+                Document(
+                    doc_id="doc-2",
+                    text="Agent security report includes MCP inventory and OWASP mappings.",
+                    metadata={"source": "kb"},
+                ),
+                Document(
+                    doc_id="doc-3",
+                    text="Latency budgets require search responses under 200 milliseconds.",
+                    metadata={"source": "kb"},
+                ),
+            ],
+            banned_keywords=["classified"],
+            tools=[
+                Tool(
+                    name="qdrant-vector-search",
+                    version="1.6.0",
+                    source="internal",
+                    description="Provides ANN retrieval for semantic search",
+                    permissions=["read:vector_store"],
+                    risk_category="medium",
+                ),
+                Tool(
+                    name="guardrails-critic",
+                    version="0.5.0",
+                    source="pypi",
+                    description="LLM-Critic validator enforcing guard policies",
+                    permissions=["invoke:model"],
+                    risk_category="low",
+                ),
+            ],
+            mcp_servers=[
+                MCPServer(
+                    name="compliance-policy-mcp",
+                    endpoint="mcp://compliance/policy",
+                    capabilities=["policies", "exceptions"],
+                    auth_mode="token",
+                )
+            ],
+            owasp_mapping={
+                "high": {"llm": "LLM02", "agentic": "AA04"},
+                "medium": {"llm": "LLM05", "agentic": "AA02"},
+                "low": {"llm": "LLM09", "agentic": "AA01"},
+            },
+        )
+
+
+@dataclass
+class OrchestratorResult:
+    response: str
+    telemetry: TelemetryCollector
+    guardrail_result: Dict[str, object]
+    documents: List[Document]
+    radar_report: RadarReport
+
+
+class CoreOrchestrator:
+    def __init__(self, config: Optional[CoreOrchestratorConfig] = None) -> None:
+        self.config = config or CoreOrchestratorConfig.demo()
+
+    def _build_agent(self, telemetry: TelemetryCollector) -> LangGraphAgent:
+        config = self.config
+        retriever = InMemoryRetriever(
+            documents=config.documents,
+            latency_ms=config.retriever_latency_ms,
+            top_k=config.retriever_top_k,
+        )
+        guardrails = Guardrails(config.banned_keywords)
+        llm = MockLLM(model_name=config.llm_model, latency_ms=config.llm_latency_ms)
+        return LangGraphAgent(
+            retriever=retriever,
+            guardrails=guardrails,
+            llm=llm,
+            tools=config.tools,
+            mcp_servers=config.mcp_servers,
+            telemetry=telemetry,
+        )
+
+    def run(self, query: str, artifact_dir: Path) -> OrchestratorResult:
+        telemetry = TelemetryCollector()
+        telemetry.record_log("orchestrator.start query=%s" % query)
+        agent = self._build_agent(telemetry)
+        with telemetry.span("orchestrator.run", component="orchestrator") as span:
+            agent_result = agent.run(query)
+            radar_report = self._run_radar_scan(agent, telemetry, artifact_dir)
+        telemetry.record_metric("orchestrator_latency_ms", span.span.duration_ms)
+        telemetry.record_log(
+            "orchestrator.complete latency=%.2fms" % span.span.duration_ms
+        )
+        return OrchestratorResult(
+            response=agent_result.response,
+            telemetry=telemetry,
+            guardrail_result=agent_result.guardrail_result,
+            documents=list(agent_result.documents),
+            radar_report=radar_report,
+        )
+
+    def _run_radar_scan(
+        self, agent: LangGraphAgent, telemetry: TelemetryCollector, artifact_dir: Path
+    ) -> RadarReport:
+        mapping = self.config.owasp_mapping or {}
+        scanner = RadarScanner(mapping, artifact_dir)
+        report = scanner.scan(agent, telemetry)
+        # Provide a stable hash summary for evidence bundling.
+        telemetry.record_metric(
+            "radar_report_checksum",
+            hash(report.json_path.read_text(encoding="utf-8")) & 0xFFFFFFFF,
+        )
+        return report

--- a/opobserve/radar.py
+++ b/opobserve/radar.py
@@ -1,0 +1,136 @@
+"""Agentic-security radar scanning + report generation primitives."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from .telemetry import TelemetryCollector
+
+
+@dataclass
+class RadarReport:
+    findings: Dict[str, object]
+    json_path: Path
+    html_path: Path
+
+
+class RadarScanner:
+    """Produces a simplified radar scan for integration testing."""
+
+    def __init__(
+        self,
+        owasp_mapping: Dict[str, Dict[str, str]],
+        evidence_dir: Path,
+    ) -> None:
+        self.owasp_mapping = owasp_mapping
+        self.evidence_dir = evidence_dir
+        self.evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    def scan(self, agent, telemetry: TelemetryCollector) -> RadarReport:
+        with telemetry.span("radar.scan", component="radar") as span:
+            workflow = agent.workflow_graph()
+            tools = agent.tool_inventory()
+            mcp_servers = agent.mcp_inventory()
+            vulnerabilities = self._identify_vulnerabilities(tools)
+            findings = {
+                "workflow": workflow,
+                "tools": tools,
+                "mcp_servers": mcp_servers,
+                "vulnerabilities": vulnerabilities,
+                "owasp_summary": [
+                    {
+                        "component": vuln["component"],
+                        "owasp": vuln["owasp"],
+                        "severity": vuln["severity"],
+                    }
+                    for vuln in vulnerabilities
+                ],
+                "evidence": {
+                    "trace_links": agent.trace_links(telemetry),
+                    "metrics": telemetry.metrics,
+                },
+            }
+            json_path = self.evidence_dir / "radar-findings.json"
+            html_path = self.evidence_dir / "radar-report.html"
+            json_path.write_text(json.dumps(findings, indent=2), encoding="utf-8")
+            html_path.write_text(self._render_html(findings), encoding="utf-8")
+        telemetry.record_metric("radar_findings", len(vulnerabilities))
+        telemetry.record_log(
+            "radar.scan.completed vulns=%s latency=%.2fms" % (len(vulnerabilities), span.span.duration_ms)
+        )
+        return RadarReport(findings=findings, json_path=json_path, html_path=html_path)
+
+    # ---- helpers ------------------------------------------------------
+    def _identify_vulnerabilities(self, tools: Sequence[Dict[str, object]]) -> List[Dict[str, object]]:
+        vulnerabilities: List[Dict[str, object]] = []
+        for tool in tools:
+            risk = tool.get("risk_category", "low")
+            mappings = self.owasp_mapping.get(risk, {"llm": "LLM10", "agentic": "A0"})
+            severity = "high" if risk == "high" else ("medium" if risk == "medium" else "low")
+            vulnerabilities.append(
+                {
+                    "component": tool["name"],
+                    "version": tool.get("version", "unknown"),
+                    "severity": severity,
+                    "owasp": {
+                        "llm": mappings.get("llm", "LLM10"),
+                        "agentic": mappings.get("agentic", "A0"),
+                    },
+                    "notes": tool.get("description", ""),
+                }
+            )
+        return vulnerabilities
+
+    def _render_html(self, findings: Dict[str, object]) -> str:
+        workflow_nodes = findings["workflow"]["nodes"]
+        workflow_edges = findings["workflow"]["edges"]
+        tools = findings["tools"]
+        mcp_servers = findings["mcp_servers"]
+        vulnerabilities = findings["vulnerabilities"]
+        evidence = findings["evidence"]
+        html_sections = [
+            "<html><head><title>Agentic Radar Report</title></head><body>",
+            "<h1>Agentic Security Radar Report</h1>",
+            "<h2>Workflow Visualization</h2>",
+            "<pre>%s</pre>" % json.dumps({"nodes": workflow_nodes, "edges": workflow_edges}, indent=2),
+            "<h2>Tool Inventory</h2>",
+            "<ul>",
+        ]
+        for tool in tools:
+            html_sections.append(
+                "<li><strong>{name}</strong> v{version} — {description} (risk: {risk})</li>".format(
+                    name=tool["name"],
+                    version=tool.get("version", "unknown"),
+                    description=tool.get("description", "n/a"),
+                    risk=tool.get("risk_category", "unknown"),
+                )
+            )
+        html_sections.extend(["</ul>", "<h2>MCP Servers</h2>", "<ul>"])
+        for server in mcp_servers:
+            html_sections.append(
+                "<li>{name} — {endpoint} ({auth_mode})</li>".format(
+                    name=server["name"], endpoint=server["endpoint"], auth_mode=server["auth_mode"]
+                )
+            )
+        html_sections.extend(["</ul>", "<h2>Vulnerability Mapping</h2>", "<table>", "<tr><th>Component</th><th>Severity</th><th>OWASP-LLM</th><th>OWASP-Agentic</th></tr>"])
+        for vuln in vulnerabilities:
+            html_sections.append(
+                "<tr><td>{component}</td><td>{severity}</td><td>{llm}</td><td>{agentic}</td></tr>".format(
+                    component=vuln["component"],
+                    severity=vuln["severity"],
+                    llm=vuln["owasp"]["llm"],
+                    agentic=vuln["owasp"]["agentic"],
+                )
+            )
+        html_sections.extend(
+            [
+                "</table>",
+                "<h2>Evidence</h2>",
+                "<p>Traces: %s</p>" % ", ".join(evidence.get("trace_links", [])),
+                "<p>Metrics keys: %s</p>" % ", ".join(sorted(evidence.get("metrics", {}).keys())),
+                "</body></html>",
+            ]
+        )
+        return "\n".join(html_sections)

--- a/opobserve/telemetry.py
+++ b/opobserve/telemetry.py
@@ -1,0 +1,99 @@
+"""Telemetry utilities for orchestrator integration tests.
+
+Provides a lightweight span/metrics collector we can use to simulate
+OpenTelemetry/OpenLLMetry style instrumentation without external
+Dependencies.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Span:
+    """Represents a captured unit of work for tracing."""
+
+    name: str
+    start_time: float
+    end_time: float
+    attributes: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def duration_ms(self) -> float:
+        """Duration in milliseconds."""
+        return (self.end_time - self.start_time) * 1000
+
+
+class SpanContext:
+    """Context manager used to capture spans."""
+
+    def __init__(self, collector: "TelemetryCollector", name: str, attrs: Dict[str, Any]):
+        self._collector = collector
+        self._name = name
+        self._attrs = attrs
+        self.span: Optional[Span] = None
+        self._start: Optional[float] = None
+
+    def __enter__(self) -> "SpanContext":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        end_time = time.perf_counter()
+        if self._start is None:
+            raise RuntimeError("SpanContext exited without being entered")
+        self.span = Span(self._name, self._start, end_time, dict(self._attrs))
+        # Attach error information if an exception bubbled up.
+        if exc_type:
+            self.span.attributes["error.type"] = exc_type.__name__
+            self.span.attributes["error.message"] = str(exc_val)
+        self._collector.spans.append(self.span)
+
+
+class TelemetryCollector:
+    """Collects metrics, logs and spans for a test run."""
+
+    def __init__(self) -> None:
+        self.metrics: Dict[str, Any] = {}
+        self.logs: List[str] = []
+        self.spans: List[Span] = []
+
+    # ---- Tracing -----------------------------------------------------
+    def span(self, name: str, **attrs: Any) -> SpanContext:
+        return SpanContext(self, name, attrs)
+
+    # ---- Metrics -----------------------------------------------------
+    def record_metric(self, name: str, value: Any) -> None:
+        self.metrics[name] = value
+
+    def increment(self, name: str, value: int = 1) -> None:
+        self.metrics[name] = self.metrics.get(name, 0) + value
+
+    # ---- Logging -----------------------------------------------------
+    def record_log(self, message: str) -> None:
+        timestamp = time.strftime("%H:%M:%S")
+        self.logs.append(f"{timestamp} {message}")
+
+    # ---- Helpers -----------------------------------------------------
+    def latest_span(self, name: str) -> Optional[Span]:
+        for span in reversed(self.spans):
+            if span.name == name:
+                return span
+        return None
+
+    def as_summary(self) -> Dict[str, Any]:
+        """Provide a consolidated view of captured telemetry."""
+        return {
+            "metrics": dict(self.metrics),
+            "logs": list(self.logs),
+            "traces": [
+                {
+                    "name": span.name,
+                    "duration_ms": span.duration_ms,
+                    "attributes": dict(span.attributes),
+                }
+                for span in self.spans
+            ],
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "op-observe"
+version = "0.1.0"
+description = "Demo orchestration harness for integration testing"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is importable without installing the package.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_orchestrator_integration.py
+++ b/tests/test_orchestrator_integration.py
@@ -1,0 +1,86 @@
+"""Integration tests for the demo core orchestrator."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from opobserve import CoreOrchestrator, CoreOrchestratorConfig
+
+
+@pytest.fixture()
+def orchestrator() -> CoreOrchestrator:
+    # Use the demo configuration but tighten latencies so the CI environment stays quick.
+    config = CoreOrchestratorConfig.demo()
+    config.retriever_latency_ms = 90.0
+    config.llm_latency_ms = 45.0
+    return CoreOrchestrator(config=config)
+
+
+def test_orchestrator_produces_full_observability(orchestrator: CoreOrchestrator, tmp_path) -> None:
+    result = orchestrator.run("observability security posture", artifact_dir=tmp_path)
+
+    # Guardrails should pass and retrieval should yield context.
+    assert result.guardrail_result["passed"] is True
+    assert result.telemetry.metrics["retrieved_documents"] >= 1
+    assert "observability" in result.response.lower()
+
+    # Metrics cover the key SLIs we expect (search latency, guard verdicts, radar checksum).
+    metrics = result.telemetry.metrics
+    assert metrics["search_latency_ms"] < 200
+    assert metrics["guardrail_pass"] == 1
+    assert metrics["radar_findings"] == len(result.radar_report.findings["vulnerabilities"])
+    assert metrics["radar_report_checksum"] > 0
+    assert metrics["orchestrator_latency_ms"] >= metrics["search_latency_ms"]
+
+    # Latency metric should match the retrieval span duration very closely.
+    retrieval_span = result.telemetry.latest_span("retriever.vector_search")
+    assert retrieval_span is not None
+    assert abs(retrieval_span.duration_ms - metrics["search_latency_ms"]) < 5
+
+    # Logs record each stage of the workflow.
+    logs = "\n".join(result.telemetry.logs)
+    assert "retrieval.ok" in logs
+    assert "guardrails.pass" in logs
+    assert "llm.generated" in logs
+    assert "radar.scan.completed" in logs
+    assert "orchestrator.complete" in logs
+
+    # Traces capture each major component including the orchestrator umbrella span.
+    span_names = [span.name for span in result.telemetry.spans]
+    assert span_names[:4] == [
+        "retriever.vector_search",
+        "guardrails.validation",
+        "llm.synthesize",
+        "radar.scan",
+    ]
+    assert span_names[-1] == "orchestrator.run"
+
+    # Reports are materialised to disk and contain the expected sections.
+    radar_report = result.radar_report
+    assert radar_report.json_path.exists()
+    assert radar_report.html_path.exists()
+
+    data = json.loads(radar_report.json_path.read_text(encoding="utf-8"))
+    assert {"workflow", "tools", "mcp_servers", "vulnerabilities", "evidence"} <= data.keys()
+    assert any(node["id"] == "retriever" for node in data["workflow"]["nodes"])
+    assert any(tool["name"] == "qdrant-vector-search" for tool in data["tools"])
+    assert data["mcp_servers"][0]["name"] == "compliance-policy-mcp"
+    assert all("owasp" in vuln for vuln in data["vulnerabilities"])
+    assert data["evidence"]["metrics"]["search_latency_ms"] == pytest.approx(metrics["search_latency_ms"], rel=0.1)
+    assert data["evidence"]["trace_links"]
+
+    html_contents = radar_report.html_path.read_text(encoding="utf-8")
+    for section in [
+        "Workflow Visualization",
+        "Tool Inventory",
+        "MCP Servers",
+        "Vulnerability Mapping",
+        "Evidence",
+    ]:
+        assert section in html_contents
+
+    # Snapshot the consolidated summary to help with debugging if the integration fails.
+    summary = result.telemetry.as_summary()
+    assert summary["metrics"]["search_latency_ms"] == pytest.approx(metrics["search_latency_ms"], rel=0.01)
+    assert len(summary["traces"]) >= 5


### PR DESCRIPTION
## Summary
- add a lightweight LangGraph-style agent and telemetry harness with retrieval, guardrails, llm synthesis, and radar scan wiring for the core orchestrator
- build radar scanning/report generation utilities that emit HTML/JSON evidence with OWASP mappings and trace links
- add integration coverage that runs the orchestrator end-to-end, asserting metrics, logs, spans, latency targets, and report artefacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b785f978832bb4f8eb1cc88250c6