### PR TITLE
Add orchestrator core module with CLI integration and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,0 +1,13 @@
+"""OP-Observe orchestration package."""
+
+from .config import Config
+from .orchestrator import Orchestrator, GuardrailViolation, ModuleNotEnabledError
+
+__all__ = [
+    "Config",
+    "Orchestrator",
+    "GuardrailViolation",
+    "ModuleNotEnabledError",
+]
+
+__version__ = "0.1.0"

--- a/op_observe/agents/__init__.py
+++ b/op_observe/agents/__init__.py
@@ -1,0 +1,16 @@
+"""Agent implementations used by the OP-Observe orchestrator."""
+
+from .enablement import EnablementAgent
+from .observability import ObservabilityAgent
+from .retrieval import Document, RetrievalAgent
+from .security import SecurityAgent
+from .telemetry import TelemetryAgent
+
+__all__ = [
+    "Document",
+    "EnablementAgent",
+    "ObservabilityAgent",
+    "RetrievalAgent",
+    "SecurityAgent",
+    "TelemetryAgent",
+]

--- a/op_observe/agents/enablement.py
+++ b/op_observe/agents/enablement.py
@@ -1,0 +1,53 @@
+"""Enablement utilities for packaging evidence bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(slots=True)
+class EvidenceBundle:
+    """Represents a packaged evidence artifact."""
+
+    digest: str
+    json_blob: str
+    html_report: str
+    created_at: float
+
+
+class EnablementAgent:
+    """Packages telemetry, RAG output, and radar reports into evidence bundles."""
+
+    def __init__(self) -> None:
+        self._initialized = False
+
+    def initialize(self) -> None:
+        self._initialized = True
+
+    def package(
+        self,
+        *,
+        rag_result: Mapping[str, object],
+        radar_results: Mapping[str, object],
+        telemetry_snapshot: Mapping[str, object],
+    ) -> EvidenceBundle:
+        if not self._initialized:
+            raise RuntimeError("EnablementAgent must be initialized before packaging evidence")
+
+        payload = {
+            "rag_result": rag_result,
+            "radar_report": radar_results.get("report_json"),
+            "telemetry": telemetry_snapshot,
+        }
+        json_blob = json.dumps(payload, sort_keys=True)
+        digest = hashlib.sha256(json_blob.encode("utf-8")).hexdigest()
+        return EvidenceBundle(
+            digest=digest,
+            json_blob=json_blob,
+            html_report=str(radar_results.get("report_html", "")),
+            created_at=time.time(),
+        )

--- a/op_observe/agents/observability.py
+++ b/op_observe/agents/observability.py
@@ -1,0 +1,46 @@
+"""Observability and guardrail helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .telemetry import TelemetryAgent
+
+
+@dataclass(slots=True)
+class GuardrailResult:
+    """Result of a guardrail evaluation."""
+
+    flagged_terms: List[str]
+    approved: bool
+
+
+class ObservabilityAgent:
+    """Applies lightweight guardrails and emits telemetry signals."""
+
+    def __init__(self, banned_terms: Iterable[str], telemetry: TelemetryAgent | None = None) -> None:
+        self._banned_terms = [term.lower() for term in banned_terms]
+        self._telemetry = telemetry
+        self._initialized = False
+
+    def initialize(self) -> None:
+        self._initialized = True
+
+    def guard(self, query: str, response: str) -> GuardrailResult:
+        if not self._initialized:
+            raise RuntimeError("ObservabilityAgent must be initialized before running guardrails")
+
+        lowered = response.lower()
+        flagged = [term for term in self._banned_terms if term and term in lowered]
+        approved = not flagged
+        if self._telemetry:
+            self._telemetry.record_event(
+                "guardrail_check",
+                {
+                    "query": query,
+                    "response_length": len(response),
+                    "flagged_terms": flagged,
+                },
+            )
+        return GuardrailResult(flagged_terms=flagged, approved=approved)

--- a/op_observe/agents/retrieval.py
+++ b/op_observe/agents/retrieval.py
@@ -1,0 +1,60 @@
+"""Lightweight retrieval agent for orchestrated RAG flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Sequence
+
+
+@dataclass(slots=True)
+class Document:
+    """Simple document container used for RAG responses."""
+
+    id: str
+    content: str
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+class RetrievalAgent:
+    """A trivial lexical retrieval agent suitable for tests and demos."""
+
+    def __init__(self, documents: Iterable[Document] | None = None) -> None:
+        self._documents: List[Document] = list(documents or [])
+        self._initialized = False
+
+    def initialize(self) -> None:
+        """Prepare in-memory indices for lexical search."""
+
+        self._normalized_docs: List[tuple[Document, set[str]]] = [
+            (doc, set(doc.content.lower().split())) for doc in self._documents
+        ]
+        self._initialized = True
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    def add_documents(self, documents: Sequence[Document]) -> None:
+        self._documents.extend(documents)
+        if self._initialized:
+            self.initialize()
+
+    def search(self, query: str, *, top_k: int = 3) -> List[Document]:
+        """Perform a naive lexical search over the documents."""
+
+        if not self._initialized:
+            raise RuntimeError("RetrievalAgent must be initialized before search")
+
+        tokens = set(query.lower().split())
+        scored: List[tuple[int, Document]] = []
+        for doc, normalized in self._normalized_docs:
+            score = sum(1 for token in tokens if token in normalized)
+            if score:
+                scored.append((score, doc))
+
+        if not scored:
+            return []
+
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        top_docs = [doc for _, doc in scored[:top_k]]
+        return top_docs

--- a/op_observe/agents/security.py
+++ b/op_observe/agents/security.py
@@ -1,0 +1,213 @@
+"""Security radar module with OWASP-oriented reporting."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from html import escape
+from typing import Iterable, List, Mapping, Sequence
+
+from .telemetry import TelemetryAgent
+
+
+@dataclass(slots=True)
+class SecurityFinding:
+    """Represents a radar finding."""
+
+    agent: str
+    component: str
+    version: str | None
+    severity: str
+    cve: str | None
+    owasp_llm: Sequence[str] = field(default_factory=tuple)
+    owasp_agentic: Sequence[str] = field(default_factory=tuple)
+    notes: str | None = None
+
+
+class SecurityAgent:
+    """Performs lightweight radar scans over agent specs."""
+
+    def __init__(
+        self,
+        vulnerability_db: Mapping[str, Mapping[str, object]] | None = None,
+        telemetry: TelemetryAgent | None = None,
+    ) -> None:
+        self._vuln_db = vulnerability_db or {}
+        self._telemetry = telemetry
+        self._initialized = False
+
+    def initialize(self) -> None:
+        self._initialized = True
+
+    def scan(self, agent_specs: Iterable[Mapping[str, object]]) -> List[SecurityFinding]:
+        if not self._initialized:
+            raise RuntimeError("SecurityAgent must be initialized before scanning")
+
+        agent_specs_list = list(agent_specs)
+        findings: List[SecurityFinding] = []
+        for agent in agent_specs_list:
+            agent_name = str(agent.get("name", "unknown"))
+            tools = agent.get("tools", [])
+            for tool in tools:
+                tool_name = str(tool.get("name", "tool"))
+                tool_version = tool.get("version")
+                vuln_info = self._vuln_db.get(tool_name)
+                if vuln_info:
+                    findings.append(
+                        SecurityFinding(
+                            agent=agent_name,
+                            component=tool_name,
+                            version=str(tool_version) if tool_version is not None else None,
+                            severity=str(vuln_info.get("severity", "unknown")),
+                            cve=str(vuln_info.get("cve")) if vuln_info.get("cve") else None,
+                            owasp_llm=tuple(vuln_info.get("owasp_llm", [])),
+                            owasp_agentic=tuple(vuln_info.get("owasp_agentic", [])),
+                            notes=str(vuln_info.get("notes")) if vuln_info.get("notes") else None,
+                        )
+                    )
+
+        if self._telemetry:
+            self._telemetry.record_event(
+                "radar_scan",
+                {
+                    "total_agents": len(agent_specs_list),
+                    "findings": len(findings),
+                },
+            )
+        return findings
+
+    def _render_workflow(self, agent_specs: Sequence[Mapping[str, object]]) -> str:
+        lines = ["Agents and tool flows:"]
+        for agent in agent_specs:
+            name = escape(str(agent.get("name", "unknown")))
+            tools = agent.get("tools", [])
+            tool_names = ", ".join(escape(str(tool.get("name", "tool"))) for tool in tools) or "No tools"
+            lines.append(f"- {name}: {tool_names}")
+        return "\n".join(lines)
+
+    def _collect_tools(self, agent_specs: Sequence[Mapping[str, object]]) -> List[Mapping[str, object]]:
+        inventory: List[Mapping[str, object]] = []
+        for agent in agent_specs:
+            for tool in agent.get("tools", []):
+                inventory.append(
+                    {
+                        "agent": agent.get("name", "unknown"),
+                        "name": tool.get("name", "tool"),
+                        "version": tool.get("version"),
+                        "source": tool.get("source", "internal"),
+                    }
+                )
+        return inventory
+
+    def _collect_mcp(self, agent_specs: Sequence[Mapping[str, object]]) -> List[Mapping[str, object]]:
+        servers: List[Mapping[str, object]] = []
+        for agent in agent_specs:
+            for server in agent.get("mcp_servers", []) or []:
+                servers.append(
+                    {
+                        "agent": agent.get("name", "unknown"),
+                        "endpoint": server.get("endpoint"),
+                        "capabilities": server.get("capabilities", []),
+                        "auth": server.get("auth", "unknown"),
+                    }
+                )
+        return servers
+
+    def render_report(
+        self,
+        *,
+        agent_specs: Sequence[Mapping[str, object]],
+        findings: Sequence[SecurityFinding],
+        telemetry_snapshot: Mapping[str, object],
+        mode: str,
+    ) -> str:
+        """Render a minimal HTML report satisfying the acceptance criteria."""
+
+        workflow = escape(self._render_workflow(agent_specs))
+        tool_inventory = "".join(
+            f"<tr><td>{escape(str(tool['agent']))}</td><td>{escape(str(tool['name']))}</td>"
+            f"<td>{escape(str(tool.get('version', 'n/a')))}</td><td>{escape(str(tool.get('source', 'internal')))}</td></tr>"
+            for tool in self._collect_tools(agent_specs)
+        )
+        mcp_inventory = "".join(
+            f"<tr><td>{escape(str(server['agent']))}</td><td>{escape(str(server.get('endpoint', '')))}</td>"
+            f"<td>{escape(', '.join(server.get('capabilities', [])))}" 
+            f"</td><td>{escape(str(server.get('auth', 'unknown')))}</td></tr>"
+            for server in self._collect_mcp(agent_specs)
+        )
+        vuln_rows = "".join(
+            f"<tr><td>{escape(finding.agent)}</td><td>{escape(finding.component)}</td>"
+            f"<td>{escape(finding.version or 'n/a')}</td><td>{escape(finding.cve or 'n/a')}</td>"
+            f"<td>{escape(finding.severity)}</td>"
+            f"<td>{escape(', '.join(finding.owasp_llm))}</td><td>{escape(', '.join(finding.owasp_agentic))}</td>"
+            f"<td>{escape(finding.notes or '')}</td></tr>"
+            for finding in findings
+        )
+        telemetry_summary = escape(str(telemetry_snapshot))
+
+        return f"""
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\" />
+<title>OP-Observe Security Report</title>
+</head>
+<body>
+<h1>Security Report</h1>
+<p>Mode: {escape(mode)}</p>
+<section>
+<h2>Workflow Visualization</h2>
+<pre>{workflow}</pre>
+</section>
+<section>
+<h2>Tool Inventory</h2>
+<table><tr><th>Agent</th><th>Tool</th><th>Version</th><th>Source</th></tr>{tool_inventory or '<tr><td colspan="4">No tools</td></tr>'}</table>
+</section>
+<section>
+<h2>MCP Servers</h2>
+<table><tr><th>Agent</th><th>Endpoint</th><th>Capabilities</th><th>Auth</th></tr>{mcp_inventory or '<tr><td colspan="4">None</td></tr>'}</table>
+</section>
+<section>
+<h2>Vulnerability Mapping</h2>
+<table><tr><th>Agent</th><th>Component</th><th>Version</th><th>CVE</th><th>Severity</th><th>OWASP-LLM</th><th>OWASP-Agentic</th><th>Notes</th></tr>{vuln_rows or '<tr><td colspan="8">No findings</td></tr>'}</table>
+</section>
+<section>
+<h2>Guards &amp; Evals</h2>
+<p>{telemetry_summary}</p>
+</section>
+</body>
+</html>
+"""
+
+    def run(
+        self,
+        *,
+        mode: str,
+        agent_specs: Sequence[Mapping[str, object]],
+        telemetry_snapshot: Mapping[str, object],
+    ) -> dict[str, object]:
+        agent_specs_list = list(agent_specs)
+        findings = self.scan(agent_specs_list)
+        report_html = self.render_report(
+            agent_specs=agent_specs_list,
+            findings=findings,
+            telemetry_snapshot=telemetry_snapshot,
+            mode=mode,
+        )
+        report_json = {
+            "mode": mode,
+            "workflow": [
+                {
+                    "agent": agent.get("name", "unknown"),
+                    "tools": agent.get("tools", []),
+                    "mcp_servers": agent.get("mcp_servers", []),
+                }
+                for agent in agent_specs_list
+            ],
+            "findings": [asdict(finding) for finding in findings],
+        }
+        return {
+            "mode": mode,
+            "findings": findings,
+            "report_html": report_html,
+            "report_json": report_json,
+        }

--- a/op_observe/agents/telemetry.py
+++ b/op_observe/agents/telemetry.py
@@ -1,0 +1,49 @@
+"""Telemetry aggregation utilities."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    """Represents a single telemetry event."""
+
+    event_type: str
+    timestamp: float
+    metadata: Dict[str, object]
+
+
+class TelemetryAgent:
+    """Stores runtime telemetry for later evidence packaging."""
+
+    def __init__(self) -> None:
+        self._events: List[TelemetryEvent] = []
+        self._initialized = False
+
+    def initialize(self) -> None:
+        self._initialized = True
+
+    def record_event(self, event_type: str, metadata: Dict[str, object] | None = None) -> None:
+        if not self._initialized:
+            raise RuntimeError("TelemetryAgent must be initialized before recording events")
+
+        event = TelemetryEvent(event_type=event_type, timestamp=time.time(), metadata=metadata or {})
+        self._events.append(event)
+
+    def snapshot(self) -> Dict[str, object]:
+        """Return a serializable snapshot of telemetry state."""
+
+        return {
+            "total_events": len(self._events),
+            "events": [
+                {
+                    "event_type": event.event_type,
+                    "timestamp": event.timestamp,
+                    "metadata": event.metadata,
+                }
+                for event in self._events
+            ],
+        }

--- a/op_observe/cli.py
+++ b/op_observe/cli.py
@@ -1,0 +1,155 @@
+"""Command-line interface for the OP-Observe orchestrator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import List
+
+from . import Config, Orchestrator
+from .agents import Document
+
+DEFAULT_DOCUMENTS: List[Document] = [
+    Document(
+        id="obs-1",
+        content="Observability pipelines ensure telemetry coverage across agents.",
+        metadata={"category": "observability"},
+    ),
+    Document(
+        id="sec-1",
+        content="Agentic security radar maps OWASP findings to actionable mitigations.",
+        metadata={"category": "security"},
+    ),
+    Document(
+        id="rag-1",
+        content="Retrieval augmented generation coordinates guardrails and evidence packing.",
+        metadata={"category": "retrieval"},
+    ),
+]
+
+DEFAULT_AGENT_SPECS = (
+    {
+        "name": "observability-agent",
+        "tools": [
+            {"name": "openllmetry", "version": "0.4", "source": "internal"},
+        ],
+        "mcp_servers": [],
+    },
+    {
+        "name": "security-radar",
+        "tools": [
+            {"name": "agentic-radar", "version": "1.2", "source": "external"},
+            {"name": "osv-scanner", "version": "2.0", "source": "external"},
+        ],
+        "mcp_servers": [
+            {"endpoint": "https://mcp.local/security", "capabilities": ["scan"], "auth": "token"}
+        ],
+    },
+)
+
+DEFAULT_VULNERABILITY_DB = {
+    "agentic-radar": {
+        "severity": "medium",
+        "cve": "CVE-2024-1234",
+        "owasp_llm": ["LLM02"],
+        "owasp_agentic": ["AGENTIC-04"],
+        "notes": "Update to 1.3 to address sandbox bypass",
+    },
+    "osv-scanner": {
+        "severity": "low",
+        "cve": None,
+        "owasp_llm": ["LLM10"],
+        "owasp_agentic": ["AGENTIC-09"],
+        "notes": "Monitor upstream feed sync windows",
+    },
+}
+
+
+def build_orchestrator() -> Orchestrator:
+    config = Config.from_env(
+        documents=DEFAULT_DOCUMENTS,
+        agent_specs=DEFAULT_AGENT_SPECS,
+        vulnerability_db=DEFAULT_VULNERABILITY_DB,
+    )
+    orchestrator = Orchestrator(config)
+    orchestrator.initialize_agents()
+    return orchestrator
+
+
+def handle_rag(args: argparse.Namespace) -> int:
+    orchestrator = build_orchestrator()
+    try:
+        result = orchestrator.run_rag_search(args.query, top_k=args.top_k)
+    except Exception as exc:  # pragma: no cover - surfaced to CLI users
+        print(f"Error executing RAG search: {exc}", file=sys.stderr)
+        return 1
+    output = {
+        "query": result.query,
+        "response": result.response,
+        "documents": result.documents,
+    }
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+def handle_radar(args: argparse.Namespace) -> int:
+    orchestrator = build_orchestrator()
+    try:
+        results = orchestrator.run_radar_scan(mode=args.mode)
+    except Exception as exc:  # pragma: no cover - surfaced to CLI users
+        print(f"Error running radar scan: {exc}", file=sys.stderr)
+        return 1
+    printable = results["report_json"]
+    print(json.dumps(printable, indent=2))
+    return 0
+
+
+def handle_evidence(args: argparse.Namespace) -> int:
+    orchestrator = build_orchestrator()
+    try:
+        rag_result = orchestrator.run_rag_search(args.query, top_k=args.top_k)
+        radar_results = orchestrator.run_radar_scan(mode=args.mode)
+        bundle = orchestrator.package_evidence(rag_result, radar_results)
+    except Exception as exc:  # pragma: no cover - surfaced to CLI users
+        print(f"Error packaging evidence: {exc}", file=sys.stderr)
+        return 1
+    output = {
+        "digest": bundle.digest,
+        "created_at": bundle.created_at,
+        "json_blob": json.loads(bundle.json_blob),
+    }
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="OP-Observe orchestration CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    rag_parser = subparsers.add_parser("rag", help="Execute a RAG query")
+    rag_parser.add_argument("query", help="User query to execute")
+    rag_parser.add_argument("--top-k", type=int, default=3, help="Number of documents to retrieve")
+    rag_parser.set_defaults(func=handle_rag)
+
+    radar_parser = subparsers.add_parser("radar", help="Run the security radar")
+    radar_parser.add_argument("--mode", default="scan", choices=["scan", "test"], help="Radar mode to execute")
+    radar_parser.set_defaults(func=handle_radar)
+
+    evidence_parser = subparsers.add_parser("evidence", help="Package an evidence bundle")
+    evidence_parser.add_argument("--query", required=True, help="Query to use for the RAG run")
+    evidence_parser.add_argument("--top-k", type=int, default=3, help="Number of documents to retrieve")
+    evidence_parser.add_argument("--mode", default="scan", choices=["scan", "test"], help="Radar mode to execute")
+    evidence_parser.set_defaults(func=handle_evidence)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/op_observe/config.py
+++ b/op_observe/config.py
@@ -1,0 +1,72 @@
+"""Configuration utilities for the OP-Observe orchestrator."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Sequence
+
+from .agents.retrieval import Document
+
+
+@dataclass(slots=True)
+class Config:
+    """Runtime configuration for the orchestrator and its agents."""
+
+    enable_observability: bool = True
+    enable_security: bool = True
+    enable_retrieval: bool = True
+    enable_telemetry: bool = True
+    enable_enablement: bool = True
+    guardrails_enabled: bool = True
+    banned_terms: Sequence[str] = field(default_factory=lambda: ("classified", "leak"))
+    documents: Sequence[Document] = field(default_factory=tuple)
+    agent_specs: Sequence[Mapping[str, object]] = field(default_factory=tuple)
+    vulnerability_db: Mapping[str, Mapping[str, object]] = field(default_factory=dict)
+
+    @staticmethod
+    def _parse_bool(value: str | None, default: bool) -> bool:
+        if value is None:
+            return default
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        return default
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        documents: Iterable[Document] | None = None,
+        agent_specs: Sequence[Mapping[str, object]] | None = None,
+        vulnerability_db: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> "Config":
+        """Create a configuration instance from environment variables."""
+
+        enable_observability = cls._parse_bool(os.getenv("OPOBS_ENABLE_OBSERVABILITY"), True)
+        enable_security = cls._parse_bool(os.getenv("OPOBS_ENABLE_SECURITY"), True)
+        enable_retrieval = cls._parse_bool(os.getenv("OPOBS_ENABLE_RETRIEVAL"), True)
+        enable_telemetry = cls._parse_bool(os.getenv("OPOBS_ENABLE_TELEMETRY"), True)
+        enable_enablement = cls._parse_bool(os.getenv("OPOBS_ENABLE_ENABLEMENT"), True)
+        guardrails_enabled = cls._parse_bool(os.getenv("OPOBS_ENABLE_GUARDRAILS"), True)
+
+        banned_env = os.getenv("OPOBS_BANNED_TERMS")
+        if banned_env:
+            banned_terms: Sequence[str] = tuple(term.strip() for term in banned_env.split(",") if term.strip())
+        else:
+            banned_terms = ("classified", "leak")
+
+        return cls(
+            enable_observability=enable_observability,
+            enable_security=enable_security,
+            enable_retrieval=enable_retrieval,
+            enable_telemetry=enable_telemetry,
+            enable_enablement=enable_enablement,
+            guardrails_enabled=guardrails_enabled,
+            banned_terms=banned_terms,
+            documents=tuple(documents or ()),
+            agent_specs=tuple(agent_specs or ()),
+            vulnerability_db=vulnerability_db or {},
+        )

--- a/op_observe/orchestrator.py
+++ b/op_observe/orchestrator.py
@@ -1,0 +1,152 @@
+"""Core orchestrator that coordinates OP-Observe agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Sequence
+
+from .agents import (
+    EnablementAgent,
+    ObservabilityAgent,
+    RetrievalAgent,
+    SecurityAgent,
+    TelemetryAgent,
+)
+from .agents.enablement import EvidenceBundle
+from .agents.observability import GuardrailResult
+from .config import Config
+
+
+class ModuleNotEnabledError(RuntimeError):
+    """Raised when invoking a module that is disabled in the configuration."""
+
+
+class GuardrailViolation(RuntimeError):
+    """Raised when guardrails reject a response."""
+
+    def __init__(self, result: GuardrailResult) -> None:
+        super().__init__(f"Guardrails rejected response: {result.flagged_terms}")
+        self.result = result
+
+
+@dataclass(slots=True)
+class RagResult:
+    """Structured response returned by the RAG pipeline."""
+
+    query: str
+    response: str
+    documents: List[Dict[str, object]]
+    guardrails: GuardrailResult | None
+
+
+class Orchestrator:
+    """Coordinates observability, security, retrieval, telemetry, and enablement agents."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.telemetry_agent: TelemetryAgent | None = None
+        self.observability_agent: ObservabilityAgent | None = None
+        self.retrieval_agent: RetrievalAgent | None = None
+        self.security_agent: SecurityAgent | None = None
+        self.enablement_agent: EnablementAgent | None = None
+        self._initialized = False
+
+    def initialize_agents(self) -> None:
+        if self.config.enable_telemetry:
+            self.telemetry_agent = TelemetryAgent()
+            self.telemetry_agent.initialize()
+        if self.config.enable_observability:
+            self.observability_agent = ObservabilityAgent(
+                self.config.banned_terms,
+                telemetry=self.telemetry_agent,
+            )
+            self.observability_agent.initialize()
+        if self.config.enable_retrieval:
+            self.retrieval_agent = RetrievalAgent(self.config.documents)
+            self.retrieval_agent.initialize()
+        if self.config.enable_security:
+            self.security_agent = SecurityAgent(
+                vulnerability_db=self.config.vulnerability_db,
+                telemetry=self.telemetry_agent,
+            )
+            self.security_agent.initialize()
+        if self.config.enable_enablement:
+            self.enablement_agent = EnablementAgent()
+            self.enablement_agent.initialize()
+        self._initialized = True
+
+    def _ensure_initialized(self) -> None:
+        if not self._initialized:
+            raise RuntimeError("Orchestrator.initialize_agents must be called before use")
+
+    def _require_module(self, module: object | None, name: str) -> object:
+        if module is None:
+            raise ModuleNotEnabledError(f"Module '{name}' is not enabled in the current configuration")
+        return module
+
+    def run_rag_search(self, query: str, *, top_k: int = 3) -> RagResult:
+        self._ensure_initialized()
+        retrieval_agent = self._require_module(self.retrieval_agent, "retrieval")
+        documents = retrieval_agent.search(query, top_k=top_k)
+        response = " ".join(doc.content for doc in documents) if documents else "No documents found."
+        guard_result: GuardrailResult | None = None
+        if self.config.guardrails_enabled:
+            observability_agent = self._require_module(self.observability_agent, "observability")
+            guard_result = observability_agent.guard(query, response)
+            if not guard_result.approved:
+                raise GuardrailViolation(guard_result)
+        telemetry = self.telemetry_agent
+        if telemetry is not None:
+            telemetry.record_event(
+                "rag_search",
+                {
+                    "query": query,
+                    "documents_returned": len(documents),
+                },
+            )
+        return RagResult(
+            query=query,
+            response=response,
+            documents=[{"id": doc.id, "content": doc.content, "metadata": doc.metadata} for doc in documents],
+            guardrails=guard_result,
+        )
+
+    def run_radar_scan(self, *, mode: str = "scan") -> dict[str, object]:
+        self._ensure_initialized()
+        security_agent = self._require_module(self.security_agent, "security")
+        telemetry_snapshot: Mapping[str, object] = (
+            self.telemetry_agent.snapshot() if self.telemetry_agent is not None else {"total_events": 0, "events": []}
+        )
+        return security_agent.run(
+            mode=mode,
+            agent_specs=self.config.agent_specs,
+            telemetry_snapshot=telemetry_snapshot,
+        )
+
+    def package_evidence(self, rag_result: RagResult, radar_results: Mapping[str, object]) -> EvidenceBundle:
+        self._ensure_initialized()
+        enablement_agent = self._require_module(self.enablement_agent, "enablement")
+        telemetry_snapshot: Mapping[str, object] = (
+            self.telemetry_agent.snapshot() if self.telemetry_agent is not None else {"total_events": 0, "events": []}
+        )
+        serialized_rag = {
+            "query": rag_result.query,
+            "response": rag_result.response,
+            "documents": rag_result.documents,
+            "guardrails": {
+                "approved": rag_result.guardrails.approved,
+                "flagged_terms": rag_result.guardrails.flagged_terms,
+            }
+            if rag_result.guardrails
+            else None,
+        }
+        return enablement_agent.package(
+            rag_result=serialized_rag,
+            radar_results=radar_results,
+            telemetry_snapshot=telemetry_snapshot,
+        )
+
+    def gather_agent_specs(self) -> Sequence[Mapping[str, object]]:
+        """Return the configured agent specifications."""
+
+        return self.config.agent_specs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "op-observe"
+version = "0.1.0"
+description = "Core orchestrator for OP-Observe observability and security platform"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4",
+]
+
+[project.scripts]
+opobserve = "op_observe.cli:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for OP-Observe tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,114 @@
+"""Integration tests for the OP-Observe orchestrator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from op_observe import Config, Orchestrator
+from op_observe.agents import Document
+from op_observe.orchestrator import GuardrailViolation
+
+
+@pytest.fixture()
+def sample_documents() -> list[Document]:
+    return [
+        Document(id="1", content="Observability telemetry integrates guardrails and radar signals."),
+        Document(id="2", content="Security radar maps OWASP findings to mitigation guidance."),
+        Document(id="3", content="Retrieval pipeline feeds evidence packaging."),
+    ]
+
+
+@pytest.fixture()
+def sample_agent_specs() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "observability",
+            "tools": [
+                {"name": "openllmetry", "version": "0.3", "source": "internal"},
+            ],
+            "mcp_servers": [],
+        },
+        {
+            "name": "security",
+            "tools": [
+                {"name": "agentic-radar", "version": "1.0", "source": "external"},
+                {"name": "legacy-tool", "version": "0.8", "source": "external"},
+            ],
+            "mcp_servers": [
+                {"endpoint": "https://security.local/mcp", "capabilities": ["scan", "test"], "auth": "token"}
+            ],
+        },
+    ]
+
+
+@pytest.fixture()
+def sample_vulnerability_db() -> dict[str, dict[str, object]]:
+    return {
+        "legacy-tool": {
+            "severity": "high",
+            "cve": "CVE-2024-9999",
+            "owasp_llm": ["LLM01", "LLM05"],
+            "owasp_agentic": ["AGENTIC-01"],
+            "notes": "Patch available in 0.9",
+        }
+    }
+
+
+@pytest.fixture()
+def orchestrator(sample_documents, sample_agent_specs, sample_vulnerability_db) -> Orchestrator:
+    config = Config(
+        documents=sample_documents,
+        agent_specs=sample_agent_specs,
+        vulnerability_db=sample_vulnerability_db,
+    )
+    orchestrator = Orchestrator(config)
+    orchestrator.initialize_agents()
+    return orchestrator
+
+
+def test_rag_flow_runs_with_guardrails(orchestrator: Orchestrator) -> None:
+    result = orchestrator.run_rag_search("security radar guidance", top_k=2)
+    assert "security" in result.response.lower()
+    assert result.guardrails is not None
+    assert result.guardrails.approved
+    assert orchestrator.telemetry_agent is not None
+    snapshot = orchestrator.telemetry_agent.snapshot()
+    assert snapshot["total_events"] >= 1
+
+
+def test_guardrails_raise_on_banned_terms(sample_documents, sample_agent_specs, sample_vulnerability_db) -> None:
+    docs = sample_documents + [Document(id="99", content="Classified leak detected")]  # banned term
+    config = Config(
+        documents=docs,
+        agent_specs=sample_agent_specs,
+        vulnerability_db=sample_vulnerability_db,
+        banned_terms=("classified",),
+    )
+    orchestrator = Orchestrator(config)
+    orchestrator.initialize_agents()
+    with pytest.raises(GuardrailViolation):
+        orchestrator.run_rag_search("classified leak", top_k=3)
+
+
+def test_radar_scan_and_evidence_packaging(orchestrator: Orchestrator) -> None:
+    radar_results = orchestrator.run_radar_scan(mode="scan")
+    assert radar_results["findings"], "Expected at least one security finding"
+    rag_result = orchestrator.run_rag_search("evidence packaging", top_k=2)
+    bundle = orchestrator.package_evidence(rag_result, radar_results)
+    assert bundle.digest
+    parsed = json.loads(bundle.json_blob)
+    assert parsed["radar_report"]["mode"] == "scan"
+    assert parsed["rag_result"]["query"] == "evidence packaging"
+
+
+def test_cli_rag_invocation() -> None:
+    cmd = [sys.executable, "-m", "op_observe.cli", "rag", "observability"]
+    completed = subprocess.run(cmd, capture_output=True, check=False, text=True)
+    assert completed.returncode == 0, completed.stderr
+    output = json.loads(completed.stdout)
+    assert output["query"] == "observability"
+    assert "response" in output


### PR DESCRIPTION
## Summary
- implement a configurable orchestrator that wires retrieval, guardrails, security radar, telemetry, and evidence enablement modules
- add a CLI surface with defaults to drive rag queries, radar scans, and evidence packaging via the orchestrator
- introduce project metadata and integration tests covering rag flow, guardrail enforcement, radar reporting, and CLI execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b77f4b9c832b94436c5518a0c921