### PR TITLE
Add Vault/Keycloak environment management and RBAC utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+.eggs/
+build/
+dist/
+*.egg-info/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# OP-Observe Environment & Secrets Utilities
+
+This repository provides utilities to configure environment variables, integrate with HashiCorp Vault and Keycloak, and manage RBAC policies for the OP-Observe platform. The modules are designed to be used in on-prem deployments where secure secret retrieval and role-based access control are required.
+
+## Features
+
+- Declarative environment configuration loader with `.env` template.
+- Keycloak OIDC client for service authentication and administrative operations.
+- Vault client helpers for OIDC authentication and KV secret retrieval.
+- Reusable RBAC policy definitions and synchronization helpers for Keycloak.
+- Tests that exercise environment parsing, OIDC token acquisition, Vault login, and RBAC reconciliation flows.
+
+## Getting Started
+
+1. Copy `env/.env.example` to `.env` and adjust values for your deployment.
+2. Install dependencies (preferably inside a virtual environment):
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+3. Run the tests:
+
+   ```bash
+   pytest
+   ```
+
+## Project Layout
+
+- `op_observe/config/environment.py` – Environment variable parsing helpers.
+- `op_observe/auth/keycloak.py` – Keycloak OIDC and admin clients.
+- `op_observe/secrets/vault.py` – Vault authentication and secret retrieval helpers.
+- `op_observe/auth/rbac.py` – Declarative RBAC policy definitions and synchronization logic.
+- `env/.env.example` – Template environment file.
+- `vault/policies/op-observe.hcl` – Example Vault policy for OP-Observe services.
+- `keycloak/rbac-policy.json` – Example Keycloak RBAC manifest.
+
+## Licensing
+
+This project is provided as-is for demonstration purposes within the OP-Observe platform.

--- a/env/.env.example
+++ b/env/.env.example
@@ -1,0 +1,37 @@
+# ============================================================================
+# OP-Observe Environment Template
+# Copy this file to `.env` and adjust values for your deployment.
+# ============================================================================
+
+# ---------------------------
+# Vault configuration
+# ---------------------------
+VAULT_ADDR=https://vault.example.com
+VAULT_NAMESPACE=
+VAULT_ROLE=op-observe
+VAULT_OIDC_AUDIENCE=vault
+VAULT_AUTH_PATH=jwt
+VAULT_KV_MOUNT=kv
+VAULT_KV_SECRET_PATH=services/op-observe
+VAULT_VERIFY_TLS=true
+
+# ---------------------------
+# Keycloak configuration
+# ---------------------------
+KEYCLOAK_BASE_URL=https://keycloak.example.com
+KEYCLOAK_REALM=op-observe
+KEYCLOAK_CLIENT_ID=op-observe-service
+KEYCLOAK_CLIENT_SECRET=replace-with-generated-secret
+KEYCLOAK_ADMIN_CLIENT_ID=admin-cli
+KEYCLOAK_ADMIN_USERNAME=admin
+KEYCLOAK_ADMIN_PASSWORD=replace-with-strong-password
+KEYCLOAK_VERIFY_TLS=true
+
+# Optional: supply a custom scope when requesting Keycloak tokens
+KEYCLOAK_SCOPE=openid profile
+
+# ---------------------------
+# RBAC policy defaults
+# ---------------------------
+RBAC_DEFAULT_GROUP=op-observe-operators
+RBAC_SERVICE_ROLES=op-observe-service,op-observe-admin

--- a/keycloak/rbac-policy.json
+++ b/keycloak/rbac-policy.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://op-observe.example.com/schemas/keycloak-rbac-policy.json",
+  "realm": "op-observe",
+  "roles": [
+    {
+      "name": "op-observe-service",
+      "description": "Allows OP-Observe services to access Vault and observability APIs",
+      "composite": false
+    },
+    {
+      "name": "op-observe-admin",
+      "description": "Administrative access to OP-Observe control plane",
+      "composite": false
+    }
+  ],
+  "groups": [
+    {
+      "name": "op-observe-operators",
+      "roles": ["op-observe-service"]
+    },
+    {
+      "name": "op-observe-admins",
+      "roles": ["op-observe-service", "op-observe-admin"]
+    }
+  ]
+}

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,0 +1,7 @@
+"""OP-Observe environment and secrets utilities."""
+
+__all__ = [
+    "config",
+    "auth",
+    "secrets",
+]

--- a/op_observe/auth/keycloak.py
+++ b/op_observe/auth/keycloak.py
@@ -1,0 +1,241 @@
+"""Keycloak authentication helpers for OP-Observe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional
+
+from op_observe.utils.http import HTTPSession, HttpResponse
+
+
+class KeycloakError(RuntimeError):
+    """Base exception for Keycloak integration errors."""
+
+
+class KeycloakAuthenticationError(KeycloakError):
+    """Raised when authentication with Keycloak fails."""
+
+
+class KeycloakRequestError(KeycloakError):
+    """Raised when the Keycloak Admin API returns an unexpected response."""
+
+
+@dataclass(slots=True)
+class KeycloakOIDCClient:
+    """Client credentials helper for Keycloak OIDC tokens."""
+
+    base_url: str
+    realm: str
+    client_id: str
+    client_secret: str
+    scope: Optional[str] = None
+    verify: bool = True
+    session: HTTPSession = field(default_factory=HTTPSession)
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.base_url}/realms/{self.realm}/protocol/openid-connect/token"
+
+    def get_token(self, *, audience: Optional[str] = None, scope: Optional[str] = None) -> dict[str, Any]:
+        """Request a client-credential access token from Keycloak."""
+
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        final_scope = scope or self.scope
+        if final_scope:
+            payload["scope"] = final_scope
+        if audience:
+            payload["audience"] = audience
+
+        response = self.session.post(
+            self.token_endpoint,
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            verify=self.verify,
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise KeycloakAuthenticationError(
+                f"Failed to obtain token from Keycloak: {response.status_code} {response.text}"
+            )
+        data = response.json()
+        if "access_token" not in data:
+            raise KeycloakAuthenticationError("Keycloak response did not include an access token")
+        return data
+
+
+@dataclass(slots=True)
+class KeycloakAdminClient:
+    """Thin wrapper around the Keycloak Admin REST API."""
+
+    base_url: str
+    realm: str
+    admin_client_id: str
+    username: str
+    password: str
+    scope: Optional[str] = None
+    verify: bool = True
+    session: HTTPSession = field(default_factory=HTTPSession)
+    _token: Optional[str] = field(default=None, init=False, repr=False)
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"{self.base_url}/realms/{self.realm}/protocol/openid-connect/token"
+
+    @property
+    def admin_base_url(self) -> str:
+        return f"{self.base_url}/admin/realms/{self.realm}"
+
+    def authenticate(self) -> str:
+        """Authenticate using Resource Owner Password Credentials flow."""
+
+        payload = {
+            "grant_type": "password",
+            "client_id": self.admin_client_id,
+            "username": self.username,
+            "password": self.password,
+        }
+        if self.scope:
+            payload["scope"] = self.scope
+
+        response = self.session.post(
+            self.token_endpoint,
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            verify=self.verify,
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise KeycloakAuthenticationError(
+                f"Failed to authenticate with Keycloak admin API: {response.status_code} {response.text}"
+            )
+        data = response.json()
+        token = data.get("access_token")
+        if not token:
+            raise KeycloakAuthenticationError("Keycloak admin authentication did not return an access token")
+        self._token = token
+        self.session.headers.update({"Authorization": f"Bearer {token}"})
+        return token
+
+    def _ensure_token(self) -> None:
+        if not self._token:
+            self.authenticate()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        expected_status: tuple[int, ...] = (200, 201, 204),
+        **kwargs: Any,
+    ) -> HttpResponse:
+        self._ensure_token()
+        url = f"{self.admin_base_url}/{path.lstrip('/')}"
+        response = self.session.request(method, url, verify=self.verify, timeout=30, **kwargs)
+        if response.status_code == 401:
+            # Token expired, re-authenticate once.
+            self.authenticate()
+            response = self.session.request(method, url, verify=self.verify, timeout=30, **kwargs)
+        if response.status_code not in expected_status:
+            raise KeycloakRequestError(
+                f"Keycloak admin API error {response.status_code} on {method.upper()} {url}: {response.text}"
+            )
+        return response
+
+    # Realm role helpers -------------------------------------------------
+    def get_realm_role(self, name: str) -> Optional[dict[str, Any]]:
+        response = self._request("get", f"roles/{name}", expected_status=(200, 404))
+        if response.status_code == 404:
+            return None
+        return response.json()
+
+    def create_realm_role(self, *, name: str, description: str, composite: bool = False) -> None:
+        self._request(
+            "post",
+            "roles",
+            json={"name": name, "description": description, "composite": composite},
+        )
+
+    def update_realm_role(self, *, name: str, description: str, composite: bool = False) -> None:
+        self._request(
+            "put",
+            f"roles/{name}",
+            json={"name": name, "description": description, "composite": composite},
+        )
+
+    # Group helpers ------------------------------------------------------
+    def find_group(self, name: str) -> Optional[dict[str, Any]]:
+        response = self._request("get", "groups", params={"search": name})
+        groups = response.json()
+        for group in groups or []:
+            if group.get("name") == name:
+                return group
+        return None
+
+    def create_group(self, name: str) -> dict[str, Any]:
+        self._request("post", "groups", json={"name": name})
+        # Keycloak returns 201 with Location header. Fetch newly created group via search.
+        group = self.find_group(name)
+        if not group:
+            raise KeycloakRequestError(f"Created group '{name}' but could not retrieve it")
+        return group
+
+    def get_group_realm_roles(self, group_id: str) -> list[dict[str, Any]]:
+        response = self._request("get", f"groups/{group_id}/role-mappings/realm")
+        return response.json() or []
+
+    def assign_group_realm_roles(self, group_id: str, roles: Iterable[dict[str, Any]]) -> None:
+        self._request(
+            "post",
+            f"groups/{group_id}/role-mappings/realm",
+            json=list(roles),
+        )
+
+    def get_user_realm_roles(self, user_id: str) -> list[dict[str, Any]]:
+        response = self._request("get", f"users/{user_id}/role-mappings/realm")
+        return response.json() or []
+
+    def assign_realm_roles_to_user(self, user_id: str, roles: Iterable[dict[str, Any]]) -> None:
+        self._request(
+            "post",
+            f"users/{user_id}/role-mappings/realm",
+            json=list(roles),
+        )
+
+    # Client helpers -----------------------------------------------------
+    def get_client_by_client_id(self, client_id: str) -> Optional[dict[str, Any]]:
+        response = self._request("get", "clients", params={"clientId": client_id})
+        clients = response.json()
+        if not clients:
+            return None
+        return clients[0]
+
+    def get_client_role(self, client_uuid: str, role_name: str) -> Optional[dict[str, Any]]:
+        response = self._request(
+            "get",
+            f"clients/{client_uuid}/roles/{role_name}",
+            expected_status=(200, 404),
+        )
+        if response.status_code == 404:
+            return None
+        return response.json()
+
+    def assign_client_roles_to_service_account(self, service_account_user_id: str, roles: Iterable[dict[str, Any]]) -> None:
+        self._request(
+            "post",
+            f"users/{service_account_user_id}/role-mappings/clients",
+            json=list(roles),
+        )
+
+    def get_service_account_user(self, client_uuid: str) -> Optional[dict[str, Any]]:
+        response = self._request(
+            "get",
+            f"clients/{client_uuid}/service-account-user",
+            expected_status=(200, 404),
+        )
+        if response.status_code == 404:
+            return None
+        return response.json()

--- a/op_observe/auth/rbac.py
+++ b/op_observe/auth/rbac.py
@@ -1,0 +1,158 @@
+"""Declarative RBAC policy management for Keycloak."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .keycloak import KeycloakAdminClient, KeycloakRequestError
+
+
+@dataclass(slots=True)
+class RoleDefinition:
+    """Definition of a realm role."""
+
+    name: str
+    description: str
+    composite: bool = False
+
+
+@dataclass(slots=True)
+class GroupBinding:
+    """Mapping between a Keycloak group and realm roles."""
+
+    name: str
+    roles: tuple[str, ...]
+
+
+@dataclass(slots=True)
+class ServiceAccountBinding:
+    """Assign realm roles to a Keycloak service account (client)."""
+
+    client_id: str
+    roles: tuple[str, ...]
+
+
+@dataclass(slots=True)
+class RBACPolicy:
+    """Collection of role definitions and their bindings."""
+
+    roles: tuple[RoleDefinition, ...]
+    groups: tuple[GroupBinding, ...]
+    service_accounts: tuple[ServiceAccountBinding, ...] = ()
+
+
+class RBACManager:
+    """Synchronize RBAC policies with Keycloak using the admin client."""
+
+    def __init__(self, admin_client: KeycloakAdminClient):
+        self._admin = admin_client
+
+    def sync_policy(self, policy: RBACPolicy) -> dict[str, object]:
+        """Apply the RBAC policy to Keycloak.
+
+        Returns a dictionary describing the changes that were made.
+        """
+
+        changes: dict[str, object] = {
+            "roles_created": [],
+            "roles_updated": [],
+            "groups_created": [],
+            "group_role_assignments": {},
+            "service_account_role_assignments": {},
+        }
+
+        role_cache: dict[str, dict[str, object]] = {}
+        # Ensure roles exist and have the expected attributes.
+        for role in policy.roles:
+            existing = self._admin.get_realm_role(role.name)
+            if existing is None:
+                self._admin.create_realm_role(
+                    name=role.name, description=role.description, composite=role.composite
+                )
+                created = self._admin.get_realm_role(role.name)
+                if created is None:  # pragma: no cover - defensive guard
+                    raise KeycloakRequestError(f"Role '{role.name}' was created but cannot be fetched")
+                role_cache[role.name] = created
+                changes["roles_created"].append(role.name)
+            else:
+                needs_update = (
+                    (existing.get("description") or "") != role.description
+                    or bool(existing.get("composite")) != role.composite
+                )
+                if needs_update:
+                    self._admin.update_realm_role(
+                        name=role.name, description=role.description, composite=role.composite
+                    )
+                    updated = self._admin.get_realm_role(role.name)
+                    role_cache[role.name] = updated if updated else existing
+                    changes["roles_updated"].append(role.name)
+                else:
+                    role_cache[role.name] = existing
+
+        # Ensure group bindings exist and have the required roles.
+        for group in policy.groups:
+            kc_group = self._admin.find_group(group.name)
+            if kc_group is None:
+                kc_group = self._admin.create_group(group.name)
+                changes["groups_created"].append(group.name)
+            current_roles = {role["name"] for role in self._admin.get_group_realm_roles(kc_group["id"])}
+            missing_role_objects = []
+            for role_name in group.roles:
+                if role_name not in role_cache:
+                    fetched = self._admin.get_realm_role(role_name)
+                    if fetched is None:
+                        raise KeycloakRequestError(
+                            f"Group '{group.name}' references unknown role '{role_name}'"
+                        )
+                    role_cache[role_name] = fetched
+                if role_name not in current_roles:
+                    missing_role_objects.append(role_cache[role_name])
+            if missing_role_objects:
+                self._admin.assign_group_realm_roles(kc_group["id"], missing_role_objects)
+                changes.setdefault("group_role_assignments", {})[group.name] = [
+                    role_obj["name"] for role_obj in missing_role_objects
+                ]
+
+        # Ensure service accounts have the expected realm roles.
+        for binding in policy.service_accounts:
+            client = self._admin.get_client_by_client_id(binding.client_id)
+            if client is None:
+                raise KeycloakRequestError(
+                    f"Service account client '{binding.client_id}' does not exist in realm"
+                )
+            service_account = self._admin.get_service_account_user(client["id"])
+            if service_account is None:
+                raise KeycloakRequestError(
+                    f"Client '{binding.client_id}' does not have an associated service account"
+                )
+            assigned_roles = {
+                role["name"] for role in self._admin.get_user_realm_roles(service_account["id"])
+            }
+            missing_roles = []
+            for role_name in binding.roles:
+                if role_name not in role_cache:
+                    fetched = self._admin.get_realm_role(role_name)
+                    if fetched is None:
+                        raise KeycloakRequestError(
+                            f"Service account '{binding.client_id}' references unknown role '{role_name}'"
+                        )
+                    role_cache[role_name] = fetched
+                if role_name not in assigned_roles:
+                    missing_roles.append(role_cache[role_name])
+            if missing_roles:
+                self._admin.assign_realm_roles_to_user(service_account["id"], missing_roles)
+                changes.setdefault("service_account_role_assignments", {})[
+                    binding.client_id
+                ] = [role["name"] for role in missing_roles]
+
+        return changes
+
+
+__all__ = [
+    "RoleDefinition",
+    "GroupBinding",
+    "ServiceAccountBinding",
+    "RBACPolicy",
+    "RBACManager",
+]

--- a/op_observe/config/__init__.py
+++ b/op_observe/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration helpers for OP-Observe."""
+
+from .environment import EnvironmentConfig, load_dotenv_file
+
+__all__ = ["EnvironmentConfig", "load_dotenv_file"]

--- a/op_observe/config/environment.py
+++ b/op_observe/config/environment.py
@@ -1,0 +1,141 @@
+"""Environment configuration utilities for OP-Observe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Optional
+import os
+
+
+class MissingEnvironmentVariableError(RuntimeError):
+    """Raised when a required environment variable is missing."""
+
+
+class InvalidEnvironmentValueError(RuntimeError):
+    """Raised when an environment variable cannot be parsed into the expected type."""
+
+
+def _str_to_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"true", "1", "yes", "y"}:
+        return True
+    if normalized in {"false", "0", "no", "n"}:
+        return False
+    raise InvalidEnvironmentValueError(f"Cannot interpret '{value}' as boolean")
+
+
+def load_dotenv_file(path: str | Path, *, override: bool = False, env: Optional[MutableMapping[str, str]] = None) -> None:
+    """Load key/value pairs from a dotenv file into the provided environment mapping.
+
+    Parameters
+    ----------
+    path:
+        The path to the dotenv file.
+    override:
+        If ``True``, values from the dotenv file replace existing environment
+        variables. Otherwise existing values are preserved.
+    env:
+        Mutable mapping that will receive the variables. Defaults to
+        :data:`os.environ`.
+    """
+
+    environment: MutableMapping[str, str] = env if env is not None else os.environ
+    dotenv_path = Path(path)
+    if not dotenv_path.exists():
+        raise FileNotFoundError(f"Dotenv file '{dotenv_path}' does not exist")
+
+    for raw_line in dotenv_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise InvalidEnvironmentValueError(
+                f"Invalid line in dotenv file '{dotenv_path}': '{raw_line}'"
+            )
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        value = raw_value.strip().strip('"').strip("'")
+        if key in environment and not override:
+            continue
+        environment[key] = value
+
+
+@dataclass(slots=True)
+class EnvironmentConfig:
+    """Structured view of OP-Observe environment variables."""
+
+    vault_addr: str
+    vault_namespace: Optional[str]
+    vault_role: str
+    vault_oidc_audience: str
+    vault_auth_path: str
+    vault_kv_mount: str
+    vault_kv_secret_path: str
+    vault_verify_tls: bool
+
+    keycloak_base_url: str
+    keycloak_realm: str
+    keycloak_client_id: str
+    keycloak_client_secret: str
+    keycloak_scope: Optional[str]
+    keycloak_admin_client_id: str
+    keycloak_admin_username: str
+    keycloak_admin_password: str
+    keycloak_verify_tls: bool
+
+    rbac_default_group: Optional[str]
+    rbac_service_roles: tuple[str, ...]
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "EnvironmentConfig":
+        mapping = env if env is not None else os.environ
+
+        def require(name: str) -> str:
+            value = mapping.get(name)
+            if value is None or value == "":
+                raise MissingEnvironmentVariableError(
+                    f"Environment variable '{name}' is required but missing"
+                )
+            return value
+
+        def optional(name: str) -> Optional[str]:
+            value = mapping.get(name)
+            if value is None or value == "":
+                return None
+            return value
+
+        def optional_bool(name: str, default: bool) -> bool:
+            value = mapping.get(name)
+            if value is None or value == "":
+                return default
+            return _str_to_bool(value)
+
+        def optional_csv(name: str) -> tuple[str, ...]:
+            value = optional(name)
+            if not value:
+                return tuple()
+            items: Iterable[str] = (item.strip() for item in value.split(","))
+            return tuple(item for item in items if item)
+
+        return cls(
+            vault_addr=require("VAULT_ADDR"),
+            vault_namespace=optional("VAULT_NAMESPACE"),
+            vault_role=require("VAULT_ROLE"),
+            vault_oidc_audience=require("VAULT_OIDC_AUDIENCE"),
+            vault_auth_path=mapping.get("VAULT_AUTH_PATH", "jwt"),
+            vault_kv_mount=mapping.get("VAULT_KV_MOUNT", "kv"),
+            vault_kv_secret_path=require("VAULT_KV_SECRET_PATH"),
+            vault_verify_tls=optional_bool("VAULT_VERIFY_TLS", True),
+            keycloak_base_url=require("KEYCLOAK_BASE_URL"),
+            keycloak_realm=require("KEYCLOAK_REALM"),
+            keycloak_client_id=require("KEYCLOAK_CLIENT_ID"),
+            keycloak_client_secret=require("KEYCLOAK_CLIENT_SECRET"),
+            keycloak_scope=optional("KEYCLOAK_SCOPE"),
+            keycloak_admin_client_id=mapping.get("KEYCLOAK_ADMIN_CLIENT_ID", "admin-cli"),
+            keycloak_admin_username=require("KEYCLOAK_ADMIN_USERNAME"),
+            keycloak_admin_password=require("KEYCLOAK_ADMIN_PASSWORD"),
+            keycloak_verify_tls=optional_bool("KEYCLOAK_VERIFY_TLS", True),
+            rbac_default_group=optional("RBAC_DEFAULT_GROUP"),
+            rbac_service_roles=optional_csv("RBAC_SERVICE_ROLES"),
+        )

--- a/op_observe/secrets/__init__.py
+++ b/op_observe/secrets/__init__.py
@@ -1,0 +1,10 @@
+"""Secret management utilities for OP-Observe."""
+
+from .vault import VaultClient, VaultError, VaultAuthenticationError, VaultRequestError
+
+__all__ = [
+    "VaultClient",
+    "VaultError",
+    "VaultAuthenticationError",
+    "VaultRequestError",
+]

--- a/op_observe/secrets/vault.py
+++ b/op_observe/secrets/vault.py
@@ -1,0 +1,160 @@
+"""Vault integration utilities for OP-Observe."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from op_observe.utils.http import HTTPSession
+
+from op_observe.auth.keycloak import KeycloakOIDCClient
+
+
+class VaultError(RuntimeError):
+    """Base exception for Vault integration errors."""
+
+
+class VaultAuthenticationError(VaultError):
+    """Raised when Vault authentication fails."""
+
+
+class VaultRequestError(VaultError):
+    """Raised when Vault operations return unexpected responses."""
+
+
+@dataclass(slots=True)
+class VaultClient:
+    """Helper for authenticating with Vault and retrieving secrets."""
+
+    address: str
+    role: str
+    oidc_audience: str
+    auth_path: str = "jwt"
+    namespace: Optional[str] = None
+    kv_mount: str = "kv"
+    verify: bool = True
+    session: HTTPSession = field(default_factory=HTTPSession)
+    _client_token: Optional[str] = field(default=None, init=False, repr=False)
+
+    def _headers(self, extra: Optional[dict[str, str]] = None) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._client_token:
+            headers["X-Vault-Token"] = self._client_token
+        if self.namespace:
+            headers["X-Vault-Namespace"] = self.namespace
+        if extra:
+            headers.update(extra)
+        return headers
+
+    def authenticate_with_oidc_token(
+        self,
+        jwt_token: str,
+        *,
+        audience: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Authenticate to Vault using an external JWT (OIDC) token."""
+
+        payload = {
+            "role": role or self.role,
+            "jwt": jwt_token,
+        }
+        if audience or self.oidc_audience:
+            payload["audience"] = audience or self.oidc_audience
+
+        response = self.session.post(
+            f"{self.address}/v1/auth/{self.auth_path}/login",
+            json=payload,
+            headers=self._headers({"Content-Type": "application/json"}),
+            verify=self.verify,
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise VaultAuthenticationError(
+                f"Vault login failed: {response.status_code} {response.text}"
+            )
+        data = response.json()
+        auth = data.get("auth") or {}
+        token = auth.get("client_token")
+        if not token:
+            raise VaultAuthenticationError("Vault login response did not include a client token")
+        self._client_token = token
+        return auth
+
+    def authenticate_with_keycloak(
+        self,
+        oidc_client: KeycloakOIDCClient,
+        *,
+        audience: Optional[str] = None,
+        scope: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Authenticate to Vault by obtaining a token from Keycloak."""
+
+        token_response = oidc_client.get_token(audience=audience or self.oidc_audience, scope=scope)
+        access_token = token_response.get("access_token")
+        if not access_token:  # pragma: no cover - defensive guard
+            raise VaultAuthenticationError("Keycloak token response missing 'access_token'")
+        return self.authenticate_with_oidc_token(access_token, audience=audience)
+
+    def _kv_data_url(self, path: str, *, mount_point: Optional[str] = None) -> str:
+        mount = mount_point or self.kv_mount
+        normalized_path = path.strip("/")
+        return f"{self.address}/v1/{mount}/data/{normalized_path}"
+
+    def read_secret(
+        self,
+        path: str,
+        *,
+        mount_point: Optional[str] = None,
+        field: Optional[str] = None,
+    ) -> Any:
+        """Read a secret from Vault's KV v2 engine."""
+
+        if not self._client_token:
+            raise VaultAuthenticationError("Vault client has not been authenticated")
+        response = self.session.get(
+            self._kv_data_url(path, mount_point=mount_point),
+            headers=self._headers(),
+            verify=self.verify,
+            timeout=30,
+        )
+        if response.status_code == 404:
+            raise VaultRequestError(f"Secret '{path}' not found")
+        if response.status_code != 200:
+            raise VaultRequestError(
+                f"Failed to read secret '{path}': {response.status_code} {response.text}"
+            )
+        payload = response.json()
+        data = payload.get("data", {}).get("data", {})
+        if field:
+            if field not in data:
+                raise VaultRequestError(
+                    f"Field '{field}' not found in secret '{path}'"
+                )
+            return data[field]
+        return data
+
+    def read_secret_metadata(self, path: str, *, mount_point: Optional[str] = None) -> dict[str, Any]:
+        """Retrieve metadata for a secret in KV v2."""
+
+        if not self._client_token:
+            raise VaultAuthenticationError("Vault client has not been authenticated")
+        mount = mount_point or self.kv_mount
+        normalized_path = path.strip("/")
+        url = f"{self.address}/v1/{mount}/metadata/{normalized_path}"
+        response = self.session.get(
+            url,
+            headers=self._headers(),
+            verify=self.verify,
+            timeout=30,
+        )
+        if response.status_code == 404:
+            raise VaultRequestError(f"Metadata for secret '{path}' not found")
+        if response.status_code != 200:
+            raise VaultRequestError(
+                f"Failed to read metadata for '{path}': {response.status_code} {response.text}"
+            )
+        return response.json().get("data", {})
+
+
+__all__ = ["VaultClient", "VaultError", "VaultAuthenticationError", "VaultRequestError"]

--- a/op_observe/utils/__init__.py
+++ b/op_observe/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for OP-Observe."""
+
+from .http import HTTPSession, HttpResponse
+
+__all__ = ["HTTPSession", "HttpResponse"]

--- a/op_observe/utils/http.py
+++ b/op_observe/utils/http.py
@@ -1,0 +1,129 @@
+"""Minimal HTTP client utilities to avoid external dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import ssl
+from typing import Any, Mapping, MutableMapping, Optional
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+@dataclass(slots=True)
+class HttpResponse:
+    """Lightweight HTTP response wrapper."""
+
+    status_code: int
+    text: str
+    headers: Mapping[str, str]
+
+    def json(self) -> Any:
+        if not self.text:
+            return None
+        try:
+            return json.loads(self.text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+            raise ValueError("Response body is not valid JSON") from exc
+
+
+class HTTPSession:
+    """Simplified HTTP session supporting the subset of requests used in the project."""
+
+    def __init__(self) -> None:
+        self.headers: MutableMapping[str, str] = {}
+
+    # Public API ----------------------------------------------------------
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Mapping[str, Any]] = None,
+        data: Any = None,
+        json: Any = None,
+        headers: Optional[Mapping[str, str]] = None,
+        verify: bool = True,
+        timeout: float = 30,
+    ) -> HttpResponse:
+        request_url = self._apply_params(url, params)
+        request_headers = dict(self.headers)
+        if headers:
+            request_headers.update(headers)
+
+        body: Optional[bytes]
+        if json is not None:
+            body = self._encode_json(json)
+            request_headers.setdefault("Content-Type", "application/json")
+        elif data is not None:
+            body = self._encode_data(data, request_headers)
+        else:
+            body = None
+
+        request = urllib.request.Request(
+            request_url,
+            data=body,
+            headers=request_headers,
+            method=method.upper(),
+        )
+        context = None
+        if not verify and request.full_url.lower().startswith("https"):
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+        try:
+            with urllib.request.urlopen(request, timeout=timeout, context=context) as response:
+                response_text = response.read().decode("utf-8")
+                response_headers = dict(response.headers.items())
+                status = response.status
+        except urllib.error.HTTPError as err:
+            response_text = err.read().decode("utf-8") if err.fp else ""
+            response_headers = dict(err.headers.items()) if err.headers else {}
+            status = err.code
+        except urllib.error.URLError as err:  # pragma: no cover - network failure
+            raise ConnectionError(err.reason) from err
+
+        return HttpResponse(status_code=status, text=response_text, headers=response_headers)
+
+    def get(self, url: str, **kwargs: Any) -> HttpResponse:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> HttpResponse:
+        return self.request("POST", url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> HttpResponse:
+        return self.request("PUT", url, **kwargs)
+
+    # Internal helpers ----------------------------------------------------
+    @staticmethod
+    def _apply_params(url: str, params: Optional[Mapping[str, Any]]) -> str:
+        if not params:
+            return url
+        parsed = urllib.parse.urlparse(url)
+        existing = dict(urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
+        merged = {**existing, **{k: str(v) for k, v in params.items()}}
+        query = urllib.parse.urlencode(merged)
+        rebuilt = parsed._replace(query=query)
+        return urllib.parse.urlunparse(rebuilt)
+
+    @staticmethod
+    def _encode_json(payload: Any) -> bytes:
+        return json.dumps(payload).encode("utf-8")
+
+    @staticmethod
+    def _encode_data(data: Any, headers: MutableMapping[str, str]) -> Optional[bytes]:
+        if data is None:
+            return None
+        if isinstance(data, bytes):
+            return data
+        if isinstance(data, str):
+            return data.encode("utf-8")
+        if isinstance(data, Mapping):
+            headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
+            return urllib.parse.urlencode({k: str(v) for k, v in data.items()}).encode("utf-8")
+        return str(data).encode("utf-8")
+
+
+__all__ = ["HTTPSession", "HttpResponse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "op-observe"
+version = "0.1.0"
+description = "Environment, secrets, and RBAC utilities for OP-Observe"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "OP-Observe Maintainers"}]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from op_observe.config import EnvironmentConfig, load_dotenv_file
+from op_observe.config.environment import InvalidEnvironmentValueError, MissingEnvironmentVariableError
+
+
+def test_load_dotenv_file(tmp_path):
+    env_file = tmp_path / "config.env"
+    env_file.write_text(
+        """
+        # comment line
+        FOO=bar
+        BAR="quoted value"
+        BAZ='another value'
+        """
+    )
+    env: dict[str, str] = {"EXISTING": "keep"}
+    load_dotenv_file(env_file, env=env)
+    assert env["FOO"] == "bar"
+    assert env["BAR"] == "quoted value"
+    assert env["BAZ"] == "another value"
+    assert env["EXISTING"] == "keep"
+
+    env["FOO"] = "orig"
+    load_dotenv_file(env_file, env=env, override=False)
+    assert env["FOO"] == "orig"
+
+    load_dotenv_file(env_file, env=env, override=True)
+    assert env["FOO"] == "bar"
+
+
+def test_load_dotenv_invalid_line(tmp_path):
+    env_file = tmp_path / "bad.env"
+    env_file.write_text("FOO\n")
+    with pytest.raises(InvalidEnvironmentValueError):
+        load_dotenv_file(env_file)
+
+
+def test_environment_config_from_env():
+    env = {
+        "VAULT_ADDR": "https://vault",
+        "VAULT_NAMESPACE": "admin",
+        "VAULT_ROLE": "op-observe",
+        "VAULT_OIDC_AUDIENCE": "vault",
+        "VAULT_AUTH_PATH": "jwt",
+        "VAULT_KV_MOUNT": "kv",
+        "VAULT_KV_SECRET_PATH": "services/op-observe",
+        "VAULT_VERIFY_TLS": "true",
+        "KEYCLOAK_BASE_URL": "https://kc",
+        "KEYCLOAK_REALM": "op",
+        "KEYCLOAK_CLIENT_ID": "client",
+        "KEYCLOAK_CLIENT_SECRET": "secret",
+        "KEYCLOAK_SCOPE": "openid profile",
+        "KEYCLOAK_ADMIN_CLIENT_ID": "admin-cli",
+        "KEYCLOAK_ADMIN_USERNAME": "admin",
+        "KEYCLOAK_ADMIN_PASSWORD": "password",
+        "KEYCLOAK_VERIFY_TLS": "false",
+        "RBAC_DEFAULT_GROUP": "operators",
+        "RBAC_SERVICE_ROLES": "op-observe-service,op-observe-admin",
+    }
+    config = EnvironmentConfig.from_env(env)
+    assert config.vault_addr == "https://vault"
+    assert config.vault_namespace == "admin"
+    assert config.vault_verify_tls is True
+    assert config.keycloak_verify_tls is False
+    assert config.rbac_service_roles == ("op-observe-service", "op-observe-admin")
+
+
+def test_environment_config_missing_required(monkeypatch):
+    monkeypatch.delenv("VAULT_ADDR", raising=False)
+    with pytest.raises(MissingEnvironmentVariableError):
+        EnvironmentConfig.from_env({})

--- a/tests/test_keycloak_vault.py
+++ b/tests/test_keycloak_vault.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from op_observe.auth.keycloak import (
+    KeycloakAdminClient,
+    KeycloakAuthenticationError,
+    KeycloakOIDCClient,
+)
+from op_observe.secrets.vault import VaultAuthenticationError, VaultClient
+
+
+def make_response(status_code: int, json_data: dict | None = None, text: str = "") -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.text = text
+    response.headers = {}
+    return response
+
+
+def test_keycloak_oidc_client_get_token():
+    session = Mock()
+    session.headers = {}
+    session.post.return_value = make_response(
+        200, {"access_token": "token", "expires_in": 60}
+    )
+
+    client = KeycloakOIDCClient(
+        base_url="https://kc.example.com",
+        realm="op",
+        client_id="service",
+        client_secret="secret",
+        scope="openid",
+        session=session,
+    )
+
+    payload = client.get_token(audience="vault")
+    assert payload["access_token"] == "token"
+    call_kwargs = session.post.call_args.kwargs
+    assert call_kwargs["data"]["audience"] == "vault"
+    assert call_kwargs["data"]["scope"] == "openid"
+
+
+def test_keycloak_admin_request_reauth_on_401():
+    session = Mock()
+    session.headers = {}
+    session.post.side_effect = [
+        make_response(200, {"access_token": "token1"}),
+        make_response(200, {"access_token": "token2"}),
+    ]
+    session.request.side_effect = [
+        make_response(401, text="expired"),
+        make_response(200, {"name": "example"}),
+    ]
+
+    admin = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        realm="op",
+        admin_client_id="admin-cli",
+        username="admin",
+        password="password",
+        session=session,
+    )
+
+    response = admin._request("get", "roles/example")
+    assert response.json()["name"] == "example"
+    assert session.post.call_count == 2
+    assert session.request.call_count == 2
+    assert admin.session.headers["Authorization"] == "Bearer token2"
+
+
+def test_vault_authenticate_with_keycloak_and_read_secret():
+    keycloak_session = Mock()
+    keycloak_session.headers = {}
+    keycloak_session.post.return_value = make_response(200, {"access_token": "oidc-token"})
+
+    vault_session = Mock()
+    vault_session.headers = {}
+    vault_session.post.return_value = make_response(
+        200, {"auth": {"client_token": "vault-token"}}
+    )
+    vault_session.get.return_value = make_response(
+        200, {"data": {"data": {"username": "svc", "password": "secret"}}}
+    )
+
+    oidc_client = KeycloakOIDCClient(
+        base_url="https://kc.example.com",
+        realm="op",
+        client_id="service",
+        client_secret="secret",
+        session=keycloak_session,
+    )
+    vault_client = VaultClient(
+        address="https://vault.example.com",
+        role="op-observe",
+        oidc_audience="vault",
+        namespace="admin",
+        session=vault_session,
+    )
+
+    auth = vault_client.authenticate_with_keycloak(oidc_client)
+    assert auth["client_token"] == "vault-token"
+    secret = vault_client.read_secret("services/op-observe", field="password")
+    assert secret == "secret"
+    vault_session.get.assert_called_once()
+    assert vault_session.get.call_args.kwargs["headers"]["X-Vault-Namespace"] == "admin"
+
+
+def test_vault_requires_authentication():
+    vault_client = VaultClient(address="https://vault", role="role", oidc_audience="vault")
+    with pytest.raises(VaultAuthenticationError):
+        vault_client.read_secret("services/op-observe")
+
+
+def test_keycloak_oidc_failure_raises():
+    session = Mock()
+    session.headers = {}
+    session.post.return_value = make_response(400, {"error": "invalid_client"}, text="bad")
+    client = KeycloakOIDCClient(
+        base_url="https://kc.example.com",
+        realm="op",
+        client_id="service",
+        client_secret="bad",
+        session=session,
+    )
+    with pytest.raises(KeycloakAuthenticationError):
+        client.get_token()

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from op_observe.auth.keycloak import KeycloakAdminClient
+from op_observe.auth.rbac import (
+    GroupBinding,
+    RBACManager,
+    RBACPolicy,
+    RoleDefinition,
+    ServiceAccountBinding,
+)
+
+
+def make_response(status_code: int, json_data: dict | None = None, text: str = "") -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.text = text
+    response.headers = {}
+    return response
+
+
+def test_rbac_manager_sync_policy_creates_roles_groups_and_bindings():
+    session = Mock()
+    session.headers = {}
+    session.post.return_value = make_response(200, {"access_token": "admintoken"})
+
+    session.request.side_effect = [
+        # Role "op-observe-service" not found
+        make_response(404, {}),
+        # Create role
+        make_response(201, {}),
+        # Fetch created role
+        make_response(
+            200,
+            {
+                "id": "role-service",
+                "name": "op-observe-service",
+                "description": "Service role",
+                "composite": False,
+            },
+        ),
+        # Role "op-observe-admin" existing but outdated
+        make_response(
+            200,
+            {
+                "id": "role-admin",
+                "name": "op-observe-admin",
+                "description": "Outdated",
+                "composite": False,
+            },
+        ),
+        # Update realm role
+        make_response(204, {}),
+        # Fetch updated role
+        make_response(
+            200,
+            {
+                "id": "role-admin",
+                "name": "op-observe-admin",
+                "description": "Administrative",
+                "composite": False,
+            },
+        ),
+        # Find group -> none
+        make_response(200, []),
+        # Create group
+        make_response(201, {}),
+        # Find group again -> now exists
+        make_response(200, [{"id": "group-operators", "name": "op-observe-operators"}]),
+        # Get existing group roles -> none
+        make_response(200, []),
+        # Assign group role mappings
+        make_response(204, {}),
+        # Get client by clientId
+        make_response(200, [{"id": "client-uuid", "clientId": "op-observe-service"}]),
+        # Get service account user
+        make_response(200, {"id": "service-account-user"}),
+        # Get service account realm roles -> none
+        make_response(200, []),
+        # Assign realm roles to service account
+        make_response(204, {}),
+    ]
+
+    admin = KeycloakAdminClient(
+        base_url="https://kc.example.com",
+        realm="op",
+        admin_client_id="admin-cli",
+        username="admin",
+        password="password",
+        session=session,
+    )
+
+    policy = RBACPolicy(
+        roles=(
+            RoleDefinition(name="op-observe-service", description="Service role"),
+            RoleDefinition(name="op-observe-admin", description="Administrative"),
+        ),
+        groups=(
+            GroupBinding(name="op-observe-operators", roles=("op-observe-service",)),
+        ),
+        service_accounts=(
+            ServiceAccountBinding(client_id="op-observe-service", roles=("op-observe-admin",)),
+        ),
+    )
+
+    changes = RBACManager(admin).sync_policy(policy)
+
+    assert changes["roles_created"] == ["op-observe-service"]
+    assert changes["roles_updated"] == ["op-observe-admin"]
+    assert changes["groups_created"] == ["op-observe-operators"]
+    assert changes["group_role_assignments"] == {
+        "op-observe-operators": ["op-observe-service"]
+    }
+    assert changes["service_account_role_assignments"] == {
+        "op-observe-service": ["op-observe-admin"]
+    }
+
+    # Ensure the admin client was authenticated exactly once.
+    assert session.post.call_count == 1

--- a/vault/policies/op-observe.hcl
+++ b/vault/policies/op-observe.hcl
@@ -1,0 +1,20 @@
+# OP-Observe Vault Policy
+# Grants services read-only access to their secrets and allows operators to list
+# metadata for auditing.
+
+path "kv/data/services/op-observe/*" {
+  capabilities = ["read", "list"]
+}
+
+path "kv/metadata/services/op-observe/*" {
+  capabilities = ["list"]
+}
+
+# Enable tokens issued via OIDC role to renew themselves while active.
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
+
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}


### PR DESCRIPTION
## Summary
- add environment configuration loader and dotenv helper with sample templates for Vault, Keycloak, and RBAC defaults
- implement lightweight HTTP session, Keycloak OIDC/admin clients, Vault secret retrieval helper, and declarative RBAC manager
- provide example Vault/Keycloak policy templates and pytest coverage for environment parsing, OIDC/Vault flows, and RBAC sync logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b76e3030832bafce21f1aff1e635