### PR TITLE
Add unified instrumentation bootstrap with tests

### DIFF
--- a/opobserve/__init__.py
+++ b/opobserve/__init__.py
@@ -1,0 +1,22 @@
+"""Top-level package for OP-Observe instrumentation utilities.
+
+This module exposes convenience imports for the instrumentation
+initialisation helpers implemented in :mod:`opobserve.instrumentation`.
+"""
+
+from .instrumentation.config import UnifiedTelemetryConfig
+from .instrumentation.registry import MetricDefinition, InstrumentationRegistry
+from .instrumentation.observability import init_observability_instrumentation
+from .instrumentation.retrieval import init_retrieval_instrumentation
+from .instrumentation.security import init_security_instrumentation
+from .instrumentation.telemetry import init_telemetry_instrumentation
+
+__all__ = [
+    "UnifiedTelemetryConfig",
+    "MetricDefinition",
+    "InstrumentationRegistry",
+    "init_observability_instrumentation",
+    "init_retrieval_instrumentation",
+    "init_security_instrumentation",
+    "init_telemetry_instrumentation",
+]

--- a/opobserve/instrumentation/__init__.py
+++ b/opobserve/instrumentation/__init__.py
@@ -1,0 +1,25 @@
+"""Instrumentation utilities for OP-Observe."""
+
+from .config import UnifiedTelemetryConfig
+from .observability import init_observability_instrumentation
+from .registry import InstrumentationRegistry, MetricDefinition, ModuleInstrumentation
+from .retrieval import init_retrieval_instrumentation
+from .security import init_security_instrumentation
+from .telemetry import init_telemetry_instrumentation
+from .utils import unique_metrics, unique_wrappers
+from .wrappers import annotate_wrapper, attach_metadata
+
+__all__ = [
+    "UnifiedTelemetryConfig",
+    "InstrumentationRegistry",
+    "MetricDefinition",
+    "ModuleInstrumentation",
+    "init_observability_instrumentation",
+    "init_retrieval_instrumentation",
+    "init_security_instrumentation",
+    "init_telemetry_instrumentation",
+    "unique_metrics",
+    "unique_wrappers",
+    "annotate_wrapper",
+    "attach_metadata",
+]

--- a/opobserve/instrumentation/config.py
+++ b/opobserve/instrumentation/config.py
@@ -1,0 +1,145 @@
+"""Configuration primitives for OpenTelemetry instrumentation.
+
+The :class:`UnifiedTelemetryConfig` data class captures the essential
+settings required for wiring OpenTelemetry tracing and metrics across the
+platform.  The object keeps the configuration serialisable and easy to
+share between modules, while providing helpers to derive OpenTelemetry
+resource attributes.
+
+Examples
+--------
+>>> from opobserve.instrumentation.config import UnifiedTelemetryConfig
+>>> config = UnifiedTelemetryConfig(service_name="guarded-rag", environment="dev")
+>>> sorted(config.resource_attributes_for().items())
+[('deployment.environment', 'dev'), ('service.name', 'guarded-rag')]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class UnifiedTelemetryConfig:
+    """Common OpenTelemetry settings shared across subsystems.
+
+    Parameters
+    ----------
+    service_name:
+        Logical name of the instrumented service or workload.  This is
+        mapped to the standard ``service.name`` resource attribute.
+    environment:
+        Deployment environment label (``production``, ``staging``,
+        ``dev``…).  Defaults to ``"production"`` following common
+        OpenTelemetry conventions.
+    tracing_endpoint:
+        Optional OTLP/HTTP or OTLP/gRPC endpoint used for tracing
+        exports.  The value is stored without validation so that callers
+        can decide how to interpret it when creating exporters.
+    metrics_endpoint:
+        Optional endpoint dedicated to metric exports.  When omitted the
+        tracing endpoint may be reused.
+    log_endpoint:
+        Optional endpoint for log shipping when the application enables
+        OpenTelemetry logs.
+    resource_attributes:
+        Extra resource attributes merged with the automatically provided
+        service metadata.  Values must be JSON serialisable to ease
+        propagation through config stores.
+    sampling_ratio:
+        Fraction of traces that should be sampled by default.  The value
+        is clamped to the ``[0.0, 1.0]`` range on initialisation.
+    """
+
+    service_name: str
+    environment: str = "production"
+    tracing_endpoint: Optional[str] = None
+    metrics_endpoint: Optional[str] = None
+    log_endpoint: Optional[str] = None
+    resource_attributes: Mapping[str, Any] = field(default_factory=dict)
+    sampling_ratio: float = 1.0
+
+    def __post_init__(self) -> None:  # pragma: no cover - handled in ``with``
+        object.__setattr__(self, "sampling_ratio", _clamp(self.sampling_ratio, 0.0, 1.0))
+
+    def resource_attributes_for(self, module: Optional[str] = None) -> Dict[str, Any]:
+        """Compute OpenTelemetry resource attributes for a module.
+
+        Parameters
+        ----------
+        module:
+            Optional module label, stored under the custom attribute
+            ``opobserve.module`` for easier filtering in observability
+            back-ends.
+
+        Returns
+        -------
+        dict
+            A copy of the resource attributes ready to be consumed by
+            OpenTelemetry SDK helpers.
+        """
+
+        base: Dict[str, Any] = {
+            "service.name": self.service_name,
+            "deployment.environment": self.environment,
+        }
+        if module:
+            base["opobserve.module"] = module
+
+        base.update(self.resource_attributes)
+        return base
+
+    def into_dict(self) -> Dict[str, Any]:
+        """Serialise the configuration to a dictionary.
+
+        The resulting mapping is convenient when passing configuration to
+        other services through JSON or when logging the effective setup.
+        A copy is returned so callers can mutate it without affecting the
+        instance.
+        """
+
+        data: Dict[str, Any] = {
+            "service_name": self.service_name,
+            "environment": self.environment,
+            "tracing_endpoint": self.tracing_endpoint,
+            "metrics_endpoint": self.metrics_endpoint,
+            "log_endpoint": self.log_endpoint,
+            "resource_attributes": dict(self.resource_attributes),
+            "sampling_ratio": self.sampling_ratio,
+        }
+        return data
+
+    def merge_resource_attributes(self, overrides: Mapping[str, Any]) -> "UnifiedTelemetryConfig":
+        """Return a copy with additional resource attributes.
+
+        The method does not mutate the current instance; instead it
+        produces a new :class:`UnifiedTelemetryConfig` with merged
+        attributes.  User-provided keys take precedence over the existing
+        ones.
+        """
+
+        merged: Dict[str, Any] = dict(self.resource_attributes)
+        merged.update(overrides)
+        return UnifiedTelemetryConfig(
+            service_name=self.service_name,
+            environment=self.environment,
+            tracing_endpoint=self.tracing_endpoint,
+            metrics_endpoint=self.metrics_endpoint,
+            log_endpoint=self.log_endpoint,
+            resource_attributes=merged,
+            sampling_ratio=self.sampling_ratio,
+        )
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    """Clamp ``value`` to the inclusive ``[low, high]`` interval."""
+
+    if value < low:
+        return low
+    if value > high:
+        return high
+    return value
+
+
+__all__ = ["UnifiedTelemetryConfig"]

--- a/opobserve/instrumentation/observability.py
+++ b/opobserve/instrumentation/observability.py
@@ -1,0 +1,74 @@
+"""Observability module instrumentation bootstrap."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .config import UnifiedTelemetryConfig
+from .registry import InstrumentationRegistry, MetricDefinition, Wrapper
+from .utils import unique_metrics, unique_wrappers
+from .wrappers import annotate_wrapper, attach_metadata
+
+_MODULE_NAME = "observability"
+
+_DEFAULT_WRAPPERS: Sequence[Wrapper] = (
+    annotate_wrapper("otel_span", f"{_MODULE_NAME}.request"),
+    attach_metadata(otel_signal="traces", otel_scope=_MODULE_NAME),
+)
+
+_DEFAULT_METRICS: Sequence[MetricDefinition] = (
+    MetricDefinition(
+        name="observability_requests_total",
+        description="Total number of guardrail validated requests",
+        instrument_type="counter",
+        unit="1",
+        value_type=int,
+    ),
+    MetricDefinition(
+        name="observability_request_latency_seconds",
+        description="Latency histogram for validated requests",
+        instrument_type="histogram",
+        unit="s",
+        value_type=float,
+    ),
+)
+
+
+def init_observability_instrumentation(
+    config: UnifiedTelemetryConfig,
+    registry: Optional[InstrumentationRegistry] = None,
+    wrappers: Optional[Sequence[Wrapper]] = None,
+    metrics: Optional[Sequence[MetricDefinition]] = None,
+) -> InstrumentationRegistry:
+    """Register observability instrumentation assets.
+
+    The function merges custom wrappers and metric definitions with the
+    module defaults and stores the resulting configuration in the provided
+    :class:`InstrumentationRegistry`.  When *registry* is ``None`` a new
+    instance is created and returned to the caller.
+
+    Examples
+    --------
+    >>> from opobserve.instrumentation import (
+    ...     UnifiedTelemetryConfig,
+    ...     InstrumentationRegistry,
+    ... )
+    >>> config = UnifiedTelemetryConfig(service_name="observability-service")
+    >>> registry = init_observability_instrumentation(config)
+    >>> registry.modules['observability'].metrics[0].name
+    'observability_requests_total'
+    """
+
+    target = registry or InstrumentationRegistry()
+    combined_wrappers = unique_wrappers(_DEFAULT_WRAPPERS, wrappers)
+    combined_metrics = unique_metrics(_DEFAULT_METRICS, metrics)
+    target.register_module(
+        _MODULE_NAME,
+        config,
+        wrappers=combined_wrappers,
+        metrics=combined_metrics,
+    )
+    return target
+
+
+__all__ = ["init_observability_instrumentation"]

--- a/opobserve/instrumentation/registry.py
+++ b/opobserve/instrumentation/registry.py
@@ -1,0 +1,134 @@
+"""Registry utilities for module specific instrumentation.
+
+The :class:`InstrumentationRegistry` keeps track of wrappers, metric
+registrations and module configurations.  The registry is intentionally
+lightweight; it does not attempt to configure exporters or providers.  A
+higher level orchestration layer can iterate over the registered modules
+and wire the OpenTelemetry SDK accordingly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, MutableMapping, Optional, Sequence
+
+from .config import UnifiedTelemetryConfig
+
+Wrapper = Callable[[Callable[..., Any]], Callable[..., Any]]
+
+
+@dataclass(frozen=True)
+class MetricDefinition:
+    """Describe a metric instrument to be created during initialisation."""
+
+    name: str
+    description: str
+    instrument_type: str = "counter"
+    unit: str = "1"
+    value_type: type = float
+
+
+@dataclass
+class ModuleInstrumentation:
+    """Container for instrumentation artefacts associated with a module."""
+
+    config: UnifiedTelemetryConfig
+    wrappers: List[Wrapper] = field(default_factory=list)
+    metrics: List[MetricDefinition] = field(default_factory=list)
+
+
+class InstrumentationRegistry:
+    """Hold instrumentation artefacts for multiple modules.
+
+    The registry is purposely minimal: it keeps track of the wrappers and
+    metric definitions so that a later bootstrap phase can configure the
+    OpenTelemetry SDK.  The class also stores a copy of the configuration
+    used by each module which makes the final pipeline reproducible.
+
+    Examples
+    --------
+    >>> from opobserve.instrumentation.config import UnifiedTelemetryConfig
+    >>> config = UnifiedTelemetryConfig(service_name="demo")
+    >>> registry = InstrumentationRegistry()
+    >>> registry.register_module("observability", config)
+    >>> sorted(registry.modules)
+    ['observability']
+    """
+
+    def __init__(self) -> None:
+        self._modules: Dict[str, ModuleInstrumentation] = {}
+
+    @property
+    def modules(self) -> MutableMapping[str, ModuleInstrumentation]:
+        """Return a mutable view of the registered modules."""
+
+        return self._modules
+
+    def register_module(
+        self,
+        module: str,
+        config: UnifiedTelemetryConfig,
+        wrappers: Optional[Sequence[Wrapper]] = None,
+        metrics: Optional[Sequence[MetricDefinition]] = None,
+    ) -> None:
+        """Register instrumentation metadata for ``module``.
+
+        Existing entries are overwritten which allows reconfiguration of a
+        module if required by the runtime environment.  Wrappers and
+        metrics are stored in insertion order which simplifies testing and
+        traceability.
+        """
+
+        entry = ModuleInstrumentation(config=config)
+        if wrappers:
+            entry.wrappers.extend(wrappers)
+        if metrics:
+            entry.metrics.extend(metrics)
+        self._modules[module] = entry
+
+    def extend_wrappers(self, module: str, wrappers: Iterable[Wrapper]) -> None:
+        """Append wrappers to a registered module.
+
+        Raises
+        ------
+        KeyError
+            If the module is unknown.
+        """
+
+        try:
+            entry = self._modules[module]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"module '{module}' has not been registered") from exc
+        entry.wrappers.extend(wrappers)
+
+    def extend_metrics(self, module: str, metrics: Iterable[MetricDefinition]) -> None:
+        """Append metric definitions to a registered module.
+
+        Raises
+        ------
+        KeyError
+            If the module is unknown.
+        """
+
+        try:
+            entry = self._modules[module]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"module '{module}' has not been registered") from exc
+        entry.metrics.extend(metrics)
+
+    def get_module(self, module: str) -> ModuleInstrumentation:
+        """Return the :class:`ModuleInstrumentation` for ``module``.
+
+        The returned instance is the live entry stored in the registry.  It
+        can therefore be mutated by callers that need to refine
+        instrumentation artefacts after the initial bootstrap.
+        """
+
+        return self._modules[module]
+
+
+__all__ = [
+    "MetricDefinition",
+    "ModuleInstrumentation",
+    "InstrumentationRegistry",
+]

--- a/opobserve/instrumentation/retrieval.py
+++ b/opobserve/instrumentation/retrieval.py
@@ -1,0 +1,71 @@
+"""Retrieval subsystem instrumentation helpers."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .config import UnifiedTelemetryConfig
+from .registry import InstrumentationRegistry, MetricDefinition, Wrapper
+from .utils import unique_metrics, unique_wrappers
+from .wrappers import annotate_wrapper, attach_metadata
+
+_MODULE_NAME = "retrieval"
+
+_DEFAULT_WRAPPERS: Sequence[Wrapper] = (
+    annotate_wrapper("otel_span", f"{_MODULE_NAME}.query"),
+    attach_metadata(otel_scope=_MODULE_NAME, retrieval_stage="vector-search"),
+)
+
+_DEFAULT_METRICS: Sequence[MetricDefinition] = (
+    MetricDefinition(
+        name="retrieval_queries_total",
+        description="Number of retrieval queries executed",
+        instrument_type="counter",
+        unit="1",
+        value_type=int,
+    ),
+    MetricDefinition(
+        name="retrieval_latency_seconds",
+        description="Histogram of retrieval latencies",
+        instrument_type="histogram",
+        unit="s",
+        value_type=float,
+    ),
+)
+
+
+def init_retrieval_instrumentation(
+    config: UnifiedTelemetryConfig,
+    registry: Optional[InstrumentationRegistry] = None,
+    wrappers: Optional[Sequence[Wrapper]] = None,
+    metrics: Optional[Sequence[MetricDefinition]] = None,
+) -> InstrumentationRegistry:
+    """Register retrieval instrumentation metadata.
+
+    The helper mirrors :func:`init_observability_instrumentation` but uses
+    retrieval specific defaults.  Custom wrappers and metrics are merged
+    with the defaults using a stable deduplication strategy to avoid
+    repeated registrations when the function is invoked multiple times.
+
+    Examples
+    --------
+    >>> from opobserve.instrumentation import UnifiedTelemetryConfig
+    >>> config = UnifiedTelemetryConfig(service_name="retriever")
+    >>> registry = init_retrieval_instrumentation(config)
+    >>> registry.modules['retrieval'].wrappers[0].__name__
+    'decorator'
+    """
+
+    target = registry or InstrumentationRegistry()
+    combined_wrappers = unique_wrappers(_DEFAULT_WRAPPERS, wrappers)
+    combined_metrics = unique_metrics(_DEFAULT_METRICS, metrics)
+    target.register_module(
+        _MODULE_NAME,
+        config,
+        wrappers=combined_wrappers,
+        metrics=combined_metrics,
+    )
+    return target
+
+
+__all__ = ["init_retrieval_instrumentation"]

--- a/opobserve/instrumentation/security.py
+++ b/opobserve/instrumentation/security.py
@@ -1,0 +1,66 @@
+"""Security and guardrail instrumentation helpers."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .config import UnifiedTelemetryConfig
+from .registry import InstrumentationRegistry, MetricDefinition, Wrapper
+from .utils import unique_metrics, unique_wrappers
+from .wrappers import annotate_wrapper, attach_metadata
+
+_MODULE_NAME = "security"
+
+_DEFAULT_WRAPPERS: Sequence[Wrapper] = (
+    annotate_wrapper("otel_span", f"{_MODULE_NAME}.guard"),
+    attach_metadata(otel_scope=_MODULE_NAME, security_signal="guardrail"),
+)
+
+_DEFAULT_METRICS: Sequence[MetricDefinition] = (
+    MetricDefinition(
+        name="security_guard_failures_total",
+        description="Count of guardrail failures detected",
+        instrument_type="counter",
+        unit="1",
+        value_type=int,
+    ),
+    MetricDefinition(
+        name="security_policy_violations_total",
+        description="Total policy violations flagged by automated checks",
+        instrument_type="counter",
+        unit="1",
+        value_type=int,
+    ),
+)
+
+
+def init_security_instrumentation(
+    config: UnifiedTelemetryConfig,
+    registry: Optional[InstrumentationRegistry] = None,
+    wrappers: Optional[Sequence[Wrapper]] = None,
+    metrics: Optional[Sequence[MetricDefinition]] = None,
+) -> InstrumentationRegistry:
+    """Register security instrumentation metadata.
+
+    Examples
+    --------
+    >>> from opobserve.instrumentation import UnifiedTelemetryConfig
+    >>> config = UnifiedTelemetryConfig(service_name="guardian")
+    >>> registry = init_security_instrumentation(config)
+    >>> [metric.name for metric in registry.modules['security'].metrics]
+    ['security_guard_failures_total', 'security_policy_violations_total']
+    """
+
+    target = registry or InstrumentationRegistry()
+    combined_wrappers = unique_wrappers(_DEFAULT_WRAPPERS, wrappers)
+    combined_metrics = unique_metrics(_DEFAULT_METRICS, metrics)
+    target.register_module(
+        _MODULE_NAME,
+        config,
+        wrappers=combined_wrappers,
+        metrics=combined_metrics,
+    )
+    return target
+
+
+__all__ = ["init_security_instrumentation"]

--- a/opobserve/instrumentation/telemetry.py
+++ b/opobserve/instrumentation/telemetry.py
@@ -1,0 +1,70 @@
+"""Telemetry pipeline instrumentation helpers."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from .config import UnifiedTelemetryConfig
+from .registry import InstrumentationRegistry, MetricDefinition, Wrapper
+from .utils import unique_metrics, unique_wrappers
+from .wrappers import annotate_wrapper, attach_metadata
+
+_MODULE_NAME = "telemetry"
+
+_DEFAULT_WRAPPERS: Sequence[Wrapper] = (
+    annotate_wrapper("otel_span", f"{_MODULE_NAME}.export"),
+    attach_metadata(otel_scope=_MODULE_NAME, otel_signal="metrics"),
+)
+
+_DEFAULT_METRICS: Sequence[MetricDefinition] = (
+    MetricDefinition(
+        name="telemetry_export_failures_total",
+        description="Number of failed telemetry export attempts",
+        instrument_type="counter",
+        unit="1",
+        value_type=int,
+    ),
+    MetricDefinition(
+        name="telemetry_export_latency_seconds",
+        description="Histogram of telemetry export latencies",
+        instrument_type="histogram",
+        unit="s",
+        value_type=float,
+    ),
+)
+
+
+def init_telemetry_instrumentation(
+    config: UnifiedTelemetryConfig,
+    registry: Optional[InstrumentationRegistry] = None,
+    wrappers: Optional[Sequence[Wrapper]] = None,
+    metrics: Optional[Sequence[MetricDefinition]] = None,
+) -> InstrumentationRegistry:
+    """Register telemetry instrumentation metadata.
+
+    The function is the final piece of the high level initialisation API
+    that provides a unified OpenTelemetry configuration surface across the
+    code base.
+
+    Examples
+    --------
+    >>> from opobserve.instrumentation import UnifiedTelemetryConfig
+    >>> config = UnifiedTelemetryConfig(service_name="collector")
+    >>> registry = init_telemetry_instrumentation(config)
+    >>> registry.modules['telemetry'].config.service_name
+    'collector'
+    """
+
+    target = registry or InstrumentationRegistry()
+    combined_wrappers = unique_wrappers(_DEFAULT_WRAPPERS, wrappers)
+    combined_metrics = unique_metrics(_DEFAULT_METRICS, metrics)
+    target.register_module(
+        _MODULE_NAME,
+        config,
+        wrappers=combined_wrappers,
+        metrics=combined_metrics,
+    )
+    return target
+
+
+__all__ = ["init_telemetry_instrumentation"]

--- a/opobserve/instrumentation/utils.py
+++ b/opobserve/instrumentation/utils.py
@@ -1,0 +1,42 @@
+"""Shared utilities for instrumentation bootstrap helpers."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from .registry import MetricDefinition, Wrapper
+
+
+def unique_wrappers(*collections: Optional[Sequence[Wrapper]]) -> List[Wrapper]:
+    """Return wrappers with duplicates removed while preserving order."""
+
+    seen: set[Wrapper] = set()
+    result: List[Wrapper] = []
+    for collection in collections:
+        if not collection:
+            continue
+        for wrapper in collection:
+            if wrapper in seen:
+                continue
+            seen.add(wrapper)
+            result.append(wrapper)
+    return result
+
+
+def unique_metrics(*collections: Optional[Sequence[MetricDefinition]]) -> List[MetricDefinition]:
+    """Return metric definitions with duplicates removed by name."""
+
+    seen: set[str] = set()
+    result: List[MetricDefinition] = []
+    for collection in collections:
+        if not collection:
+            continue
+        for metric in collection:
+            if metric.name in seen:
+                continue
+            seen.add(metric.name)
+            result.append(metric)
+    return result
+
+
+__all__ = ["unique_wrappers", "unique_metrics"]

--- a/opobserve/instrumentation/wrappers.py
+++ b/opobserve/instrumentation/wrappers.py
@@ -1,0 +1,46 @@
+"""Helper factories to construct lightweight instrumentation wrappers."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable
+
+from .registry import Wrapper
+
+
+def annotate_wrapper(attribute: str, value: str) -> Wrapper:
+    """Return a wrapper that annotates the wrapped callable.
+
+    The decorator attaches ``attribute`` with the provided ``value`` to the
+    wrapper which makes it easy for downstream integrations to inspect the
+    instrumentation intent without requiring concrete OpenTelemetry
+    dependencies at import time.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        setattr(wrapped, attribute, value)
+        return wrapped
+
+    return decorator
+
+
+def attach_metadata(**metadata: str) -> Wrapper:
+    """Attach arbitrary string metadata to the wrapped callable."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        for key, value in metadata.items():
+            setattr(wrapped, key, value)
+        return wrapped
+
+    return decorator
+
+
+__all__ = ["annotate_wrapper", "attach_metadata"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for ensuring the package is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+"""Tests for the telemetry configuration primitives."""
+
+from __future__ import annotations
+
+from opobserve.instrumentation.config import UnifiedTelemetryConfig
+
+
+def test_resource_attributes_include_service_and_environment() -> None:
+    config = UnifiedTelemetryConfig(
+        service_name="secure-rag",
+        environment="staging",
+        resource_attributes={"team": "sre"},
+    )
+
+    attrs = config.resource_attributes_for("observability")
+    assert attrs["service.name"] == "secure-rag"
+    assert attrs["deployment.environment"] == "staging"
+    assert attrs["opobserve.module"] == "observability"
+    assert attrs["team"] == "sre"
+
+
+def test_sampling_ratio_is_clamped() -> None:
+    config = UnifiedTelemetryConfig(service_name="svc", sampling_ratio=42.0)
+    assert config.sampling_ratio == 1.0
+
+    config = UnifiedTelemetryConfig(service_name="svc", sampling_ratio=-1.0)
+    assert config.sampling_ratio == 0.0
+
+
+def test_merge_resource_attributes_returns_new_instance() -> None:
+    config = UnifiedTelemetryConfig(service_name="svc", resource_attributes={"a": 1})
+    updated = config.merge_resource_attributes({"b": 2, "a": 3})
+
+    assert config.resource_attributes["a"] == 1
+    assert updated.resource_attributes["a"] == 3
+    assert updated.resource_attributes["b"] == 2
+    assert updated is not config
+
+
+def test_into_dict_produces_copy() -> None:
+    config = UnifiedTelemetryConfig(service_name="svc", environment="qa")
+    data = config.into_dict()
+    data["service_name"] = "mutated"
+
+    assert config.service_name == "svc"
+    assert data["environment"] == "qa"

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -1,0 +1,65 @@
+"""Tests for the high-level instrumentation initialisers."""
+
+from __future__ import annotations
+
+from opobserve.instrumentation import (
+    InstrumentationRegistry,
+    MetricDefinition,
+    UnifiedTelemetryConfig,
+    init_observability_instrumentation,
+    init_retrieval_instrumentation,
+    init_security_instrumentation,
+    init_telemetry_instrumentation,
+)
+from opobserve.instrumentation.wrappers import annotate_wrapper
+
+
+def test_observability_initialisation_registers_defaults() -> None:
+    config = UnifiedTelemetryConfig(service_name="svc")
+    registry = init_observability_instrumentation(config)
+
+    module = registry.get_module("observability")
+    names = [metric.name for metric in module.metrics]
+    assert "observability_requests_total" in names
+    assert "observability_request_latency_seconds" in names
+    assert len(module.wrappers) == 2
+
+
+def test_reuse_registry_registers_all_modules() -> None:
+    config = UnifiedTelemetryConfig(service_name="svc")
+    registry = InstrumentationRegistry()
+
+    init_observability_instrumentation(config, registry=registry)
+    init_retrieval_instrumentation(config, registry=registry)
+    init_security_instrumentation(config, registry=registry)
+    init_telemetry_instrumentation(config, registry=registry)
+
+    assert set(registry.modules) == {"observability", "retrieval", "security", "telemetry"}
+
+
+def test_customisation_merges_without_duplicates() -> None:
+    config = UnifiedTelemetryConfig(service_name="svc")
+    registry = init_observability_instrumentation(config)
+
+    module = registry.get_module("observability")
+    duplicate_wrapper = module.wrappers[0]
+    duplicate_metric_name = module.metrics[0].name
+
+    custom_wrapper = annotate_wrapper("otel_span", "custom")
+    custom_metric = MetricDefinition(name="custom_metric", description="custom")
+    duplicate_metric = MetricDefinition(name=duplicate_metric_name, description="ignored")
+
+    init_observability_instrumentation(
+        config,
+        registry=registry,
+        wrappers=(duplicate_wrapper, custom_wrapper),
+        metrics=(duplicate_metric, custom_metric),
+    )
+
+    module = registry.get_module("observability")
+    assert module.wrappers.count(duplicate_wrapper) == 1
+    assert custom_wrapper in module.wrappers
+
+    names = [metric.name for metric in module.metrics]
+    assert names.count(duplicate_metric_name) == 1
+    assert "custom_metric" in names

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,56 @@
+"""Tests for the instrumentation registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from opobserve.instrumentation.config import UnifiedTelemetryConfig
+from opobserve.instrumentation.registry import (
+    InstrumentationRegistry,
+    MetricDefinition,
+)
+from opobserve.instrumentation.wrappers import annotate_wrapper
+
+
+def sample_wrapper() -> None:
+    pass
+
+
+def test_register_module_stores_wrappers_and_metrics() -> None:
+    registry = InstrumentationRegistry()
+    config = UnifiedTelemetryConfig(service_name="svc")
+    wrapper = annotate_wrapper("otel_span", "demo")
+    metric = MetricDefinition(name="demo_total", description="Demo counter")
+
+    registry.register_module("demo", config, wrappers=[wrapper], metrics=[metric])
+
+    module = registry.get_module("demo")
+    assert module.config is config
+    assert module.wrappers == [wrapper]
+    assert module.metrics == [metric]
+
+
+def test_extend_helpers_append_data() -> None:
+    registry = InstrumentationRegistry()
+    config = UnifiedTelemetryConfig(service_name="svc")
+    registry.register_module("demo", config)
+
+    extra_wrapper = annotate_wrapper("otel_span", "extra")
+    extra_metric = MetricDefinition(name="extra", description="Extra metric")
+
+    registry.extend_wrappers("demo", [extra_wrapper])
+    registry.extend_metrics("demo", [extra_metric])
+
+    module = registry.get_module("demo")
+    assert extra_wrapper in module.wrappers
+    assert extra_metric in module.metrics
+
+
+def test_extend_helpers_raise_for_unknown_module() -> None:
+    registry = InstrumentationRegistry()
+
+    with pytest.raises(KeyError):
+        registry.extend_wrappers("unknown", [])
+
+    with pytest.raises(KeyError):
+        registry.extend_metrics("unknown", [])


### PR DESCRIPTION
## Summary
- create a reusable instrumentation package with unified telemetry configuration helpers
- add module-specific initialisers for observability, retrieval, security, and telemetry
- add unit tests that cover configuration merging, registry behaviour, and initializer deduplication

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b755ef1c832b9ee114d83d920f67