### PR TITLE
feat: add Phoenix telemetry exporter and dashboards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "op-observe"
+version = "0.1.0"
+description = "Phoenix integration utilities for OP-Observe"
+authors = [{name = "OP-Observe Team"}]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/op_observe/__init__.py
+++ b/src/op_observe/__init__.py
@@ -1,0 +1,21 @@
+"""OP-Observe package entry point.
+
+This module exposes high-level integration helpers for exporting telemetry
+into the Phoenix UI.
+"""
+
+from .phoenix.client import EvaluationResult, PhoenixClient
+from .phoenix.exporter import PhoenixExporter
+from .telemetry.models import Dataset, EvaluationMetric, TelemetryBatch, TraceSpan
+
+__all__ = [
+    "Dataset",
+    "EvaluationMetric",
+    "EvaluationResult",
+    "PhoenixClient",
+    "PhoenixExporter",
+    "TelemetryBatch",
+    "TraceSpan",
+]
+
+__version__ = "0.1.0"

--- a/src/op_observe/dashboards/__init__.py
+++ b/src/op_observe/dashboards/__init__.py
@@ -1,0 +1,6 @@
+"""Phoenix dashboard definitions for OP-Observe."""
+
+from .models import DashboardSpec, PanelSpec
+from .phoenix import default_dashboards, iter_dashboard_dicts
+
+__all__ = ["DashboardSpec", "PanelSpec", "default_dashboards", "iter_dashboard_dicts"]

--- a/src/op_observe/dashboards/models.py
+++ b/src/op_observe/dashboards/models.py
@@ -1,0 +1,45 @@
+"""Dashboard specification models for Phoenix UI."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+
+@dataclass(slots=True)
+class PanelSpec:
+    """Represents a single Phoenix dashboard panel."""
+
+    title: str
+    description: str
+    query: str
+    visualization: str = "time_series"
+    unit: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "title": self.title,
+            "description": self.description,
+            "query": self.query,
+            "visualization": self.visualization,
+        }
+        if self.unit:
+            payload["unit"] = self.unit
+        return payload
+
+
+@dataclass(slots=True)
+class DashboardSpec:
+    """Collection of panels describing a Phoenix dashboard."""
+
+    title: str
+    description: str
+    panels: List[PanelSpec] = field(default_factory=list)
+    tags: Sequence[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "title": self.title,
+            "description": self.description,
+            "tags": list(self.tags),
+            "panels": [panel.to_dict() for panel in self.panels],
+        }

--- a/src/op_observe/dashboards/phoenix.py
+++ b/src/op_observe/dashboards/phoenix.py
@@ -1,0 +1,108 @@
+"""Default Phoenix dashboard definitions."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .models import DashboardSpec, PanelSpec
+
+
+TRACE_OVERVIEW_DASHBOARD = DashboardSpec(
+    title="Phoenix Trace Observatory",
+    description=(
+        "Operational overview of OpenInference traces exported from the telemetry "
+        "pipeline into Phoenix. Panels assume metrics were written to the Phoenix "
+        "Postgres warehouse via the collector."
+    ),
+    tags=("phoenix", "traces", "opobserve"),
+    panels=[
+        PanelSpec(
+            title="Trace Throughput",
+            description="Requests per minute for the selected dataset",
+            query=(
+                "SELECT $__timeGroupAlias(start_time, '1 minute') AS time, "
+                "COUNT(*) AS requests_per_minute "
+                "FROM phoenix.traces "
+                "WHERE dataset_name = $dataset AND $__timeFilter(start_time) "
+                "GROUP BY 1 ORDER BY 1"
+            ),
+            visualization="time_series",
+            unit="req/min",
+        ),
+        PanelSpec(
+            title="LLM Latency (p95)",
+            description="95th percentile span latency grouped by operation",
+            query=(
+                "SELECT operation_name, percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms) "
+                "AS p95_latency_ms FROM phoenix.spans "
+                "WHERE dataset_name = $dataset AND $__timeFilter(start_time) "
+                "GROUP BY operation_name ORDER BY p95_latency_ms DESC"
+            ),
+            visualization="bar",
+            unit="ms",
+        ),
+        PanelSpec(
+            title="Guardrail Verdict Rate",
+            description="Share of traces flagged by guardrail verdict attributes",
+            query=(
+                "SELECT $__timeGroupAlias(start_time, '5 minutes') AS time, "
+                "AVG(CASE WHEN attributes->>'guardrail.verdict' = 'fail' THEN 1 ELSE 0 END) * 100 AS failure_rate "
+                "FROM phoenix.traces "
+                "WHERE dataset_name = $dataset AND attributes ? 'guardrail.verdict' "
+                "AND $__timeFilter(start_time) GROUP BY 1 ORDER BY 1"
+            ),
+            visualization="time_series",
+            unit="percent",
+        ),
+    ],
+)
+
+EVALUATION_MONITOR_DASHBOARD = DashboardSpec(
+    title="Phoenix Evaluation Monitor",
+    description="Aggregated evaluation metrics as emitted by the exporter.",
+    tags=("phoenix", "evaluations", "opobserve"),
+    panels=[
+        PanelSpec(
+            title="Evaluation Scores",
+            description="Distribution of evaluation scores per evaluation name",
+            query=(
+                "SELECT evaluation_name, percentile_cont(0.5) WITHIN GROUP (ORDER BY score) AS median_score, "
+                "percentile_cont(0.9) WITHIN GROUP (ORDER BY score) AS p90_score "
+                "FROM phoenix.evaluations WHERE dataset_id = $dataset_id GROUP BY evaluation_name"
+            ),
+            visualization="table",
+        ),
+        PanelSpec(
+            title="LLM-Critic Trend",
+            description="Time series of LLM-Critic scores from evaluation metadata",
+            query=(
+                "SELECT $__timeGroupAlias(timestamp, '15 minutes') AS time, AVG(results->'metrics'->>'critic_score')::float AS critic_score "
+                "FROM phoenix.evaluation_results WHERE evaluation_name = 'llm_critic' "
+                "AND dataset_id = $dataset_id AND $__timeFilter(timestamp) GROUP BY 1 ORDER BY 1"
+            ),
+            visualization="time_series",
+        ),
+        PanelSpec(
+            title="Evaluation Failures",
+            description="Count of failed evaluations grouped by failure reason",
+            query=(
+                "SELECT metadata->>'failure_reason' AS reason, COUNT(*) AS failures "
+                "FROM phoenix.evaluation_results WHERE dataset_id = $dataset_id "
+                "AND metadata ? 'failure_reason' GROUP BY reason ORDER BY failures DESC"
+            ),
+            visualization="bar",
+        ),
+    ],
+)
+
+
+def default_dashboards() -> List[DashboardSpec]:
+    """Return the default dashboard specifications for Phoenix."""
+
+    return [TRACE_OVERVIEW_DASHBOARD, EVALUATION_MONITOR_DASHBOARD]
+
+
+def iter_dashboard_dicts() -> Iterable[dict]:
+    """Yield dashboard payloads as dictionaries."""
+
+    for dashboard in default_dashboards():
+        yield dashboard.to_dict()

--- a/src/op_observe/phoenix/__init__.py
+++ b/src/op_observe/phoenix/__init__.py
@@ -1,0 +1,6 @@
+"""Phoenix integration helpers."""
+
+from .client import EvaluationResult, PhoenixClient
+from .exporter import PhoenixExporter
+
+__all__ = ["EvaluationResult", "PhoenixClient", "PhoenixExporter"]

--- a/src/op_observe/phoenix/client.py
+++ b/src/op_observe/phoenix/client.py
@@ -1,0 +1,117 @@
+"""Phoenix API client utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from ..telemetry.models import Dataset
+
+Transport = Callable[[str, str, Mapping[str, Any]], Mapping[str, Any]]
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(slots=True)
+class EvaluationResult:
+    """Structured evaluation payload sent to Phoenix."""
+
+    record_id: str
+    trace_id: str
+    metrics: MutableMapping[str, float]
+    timestamp: datetime
+    span_id: Optional[str] = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.record_id:
+            raise ValueError("record_id must be provided")
+        if not self.trace_id:
+            raise ValueError("trace_id must be provided")
+        if not self.metrics:
+            raise ValueError("metrics must not be empty")
+        self.timestamp = _ensure_utc(self.timestamp)
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "record_id": self.record_id,
+            "trace_id": self.trace_id,
+            "timestamp": self.timestamp.isoformat(),
+            "metrics": dict(self.metrics),
+        }
+        if self.span_id:
+            payload["span_id"] = self.span_id
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class PhoenixClient:
+    """Minimal Phoenix API client.
+
+    The client keeps a cache of dataset identifiers to avoid duplicate
+    registrations and exposes helpers for trace and evaluation ingestion.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        transport: Optional[Transport] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._transport = transport or self._default_transport
+        self._dataset_cache: Dict[str, str] = {}
+
+    def _default_transport(self, method: str, path: str, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        raise RuntimeError(
+            "PhoenixClient transport not configured; provide a callable via the transport argument."
+        )
+
+    def register_dataset(self, dataset: Dataset) -> str:
+        """Register a dataset if necessary and return its Phoenix identifier."""
+
+        if dataset.name in self._dataset_cache:
+            return self._dataset_cache[dataset.name]
+
+        response = self._transport("POST", "/v1/datasets", dataset.to_payload())
+        dataset_id = response.get("dataset_id") or response.get("id")
+        if not dataset_id:
+            raise ValueError("Phoenix response missing dataset identifier")
+        self._dataset_cache[dataset.name] = str(dataset_id)
+        return str(dataset_id)
+
+    def log_spans(self, dataset_id: str, spans: Iterable[Mapping[str, Any]]) -> Mapping[str, Any]:
+        spans_list = [dict(span) for span in spans if span]
+        if not spans_list:
+            return {}
+        return self._transport(
+            "POST",
+            f"/v1/datasets/{dataset_id}/spans",
+            {"spans": spans_list},
+        )
+
+    def update_evaluation(
+        self,
+        dataset_id: str,
+        evaluation_name: str,
+        results: Iterable[EvaluationResult],
+    ) -> Mapping[str, Any]:
+        payload_results = [result.to_payload() for result in results]
+        if not payload_results:
+            return {}
+        return self._transport(
+            "POST",
+            f"/v1/datasets/{dataset_id}/evaluations/{evaluation_name}",
+            {
+                "dataset_id": dataset_id,
+                "evaluation_name": evaluation_name,
+                "results": payload_results,
+            },
+        )
+
+    def dataset_registered(self, dataset_name: str) -> bool:
+        return dataset_name in self._dataset_cache

--- a/src/op_observe/phoenix/exporter.py
+++ b/src/op_observe/phoenix/exporter.py
@@ -1,0 +1,111 @@
+"""Utilities for exporting telemetry batches to Phoenix."""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+from .client import EvaluationResult, PhoenixClient
+from ..telemetry.models import EvaluationMetric, TelemetryBatch, TraceSpan
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _clean_dict(data: Mapping[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in data.items() if value is not None}
+
+
+@dataclass
+class PhoenixExporter:
+    """High-level helper that exports telemetry batches to Phoenix."""
+
+    client: PhoenixClient
+
+    def export_batch(self, batch: TelemetryBatch) -> str:
+        """Export traces and evaluations to Phoenix.
+
+        The method ensures that the dataset is registered, uploads OpenInference
+        spans, and upserts evaluation results grouped by evaluation name.
+        """
+
+        dataset_id = self.client.register_dataset(batch.dataset)
+        spans_payload = [self._span_to_payload(span) for span in batch.iter_spans()]
+        if spans_payload:
+            self.client.log_spans(dataset_id, spans_payload)
+
+        grouped_evaluations = self._group_evaluations(batch.iter_evaluations())
+        for evaluation_name, results in grouped_evaluations.items():
+            self.client.update_evaluation(dataset_id, evaluation_name, results)
+        return dataset_id
+
+    def _span_to_payload(self, span: TraceSpan) -> Dict[str, Any]:
+        attributes, open_inference = self._split_open_inference(span.attributes)
+        payload: Dict[str, Any] = {
+            "trace_id": span.trace_id,
+            "span_id": span.span_id,
+            "name": span.name,
+            "start_time": span.start_time.isoformat(),
+            "end_time": span.end_time.isoformat(),
+            "duration_ms": span.duration_ms,
+        }
+        if span.parent_span_id:
+            payload["parent_span_id"] = span.parent_span_id
+        if span.kind:
+            payload["kind"] = span.kind
+        status = _clean_dict({"code": span.status_code, "message": span.status_message})
+        if status:
+            payload["status"] = status
+        if attributes:
+            payload["attributes"] = _clean_dict(attributes)
+        if open_inference:
+            payload["open_inference"] = open_inference
+        return payload
+
+    def _split_open_inference(
+        self, attributes: MutableMapping[str, Any]
+    ) -> tuple[Dict[str, Any], Dict[str, Any]]:
+        general: Dict[str, Any] = {}
+        open_inference: Dict[str, Any] = {}
+        for key, value in attributes.items():
+            if key.startswith("openinference."):
+                open_inference[key.split(".", 1)[1]] = value
+            else:
+                general[key] = value
+        return general, open_inference
+
+    def _group_evaluations(
+        self, evaluations: Iterable[EvaluationMetric]
+    ) -> Dict[str, List[EvaluationResult]]:
+        grouped: Dict[str, Dict[str, EvaluationResult]] = defaultdict(dict)
+        for metric in evaluations:
+            record_id = str(metric.metadata.get("record_id") or metric.trace_id)
+            evaluation_bucket = grouped[metric.evaluation_name]
+            if record_id not in evaluation_bucket:
+                metadata = dict(metric.metadata)
+                metadata.pop("record_id", None)
+                evaluation_bucket[record_id] = EvaluationResult(
+                    record_id=record_id,
+                    trace_id=metric.trace_id,
+                    span_id=metric.span_id,
+                    metrics={metric.metric_name: float(metric.value)},
+                    metadata=metadata,
+                    timestamp=metric.timestamp,
+                )
+            else:
+                result = evaluation_bucket[record_id]
+                result.metrics[metric.metric_name] = float(metric.value)
+                if metric.metadata:
+                    metadata = dict(metric.metadata)
+                    metadata.pop("record_id", None)
+                    result.metadata.update(metadata)
+                candidate_ts = _ensure_utc(metric.timestamp)
+                if candidate_ts > result.timestamp:
+                    result.timestamp = candidate_ts
+                if metric.span_id and not result.span_id:
+                    result.span_id = metric.span_id
+        return {name: list(results.values()) for name, results in grouped.items()}

--- a/src/op_observe/telemetry/__init__.py
+++ b/src/op_observe/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry helpers for OP-Observe."""
+
+from .models import Dataset, EvaluationMetric, TelemetryBatch, TraceSpan
+
+__all__ = ["Dataset", "EvaluationMetric", "TelemetryBatch", "TraceSpan"]

--- a/src/op_observe/telemetry/models.py
+++ b/src/op_observe/telemetry/models.py
@@ -1,0 +1,107 @@
+"""Telemetry models used to structure trace and evaluation data."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    """Normalise a datetime to UTC with tzinfo."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(slots=True)
+class Dataset:
+    """Metadata describing a Phoenix dataset."""
+
+    name: str
+    schema: Mapping[str, str]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("dataset name must be provided")
+        if not isinstance(self.schema, Mapping) or not self.schema:
+            raise ValueError("dataset schema must be a non-empty mapping")
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Return a serialisable payload for Phoenix dataset registration."""
+        return {
+            "name": self.name,
+            "schema": dict(self.schema),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class TraceSpan:
+    """Representation of a single OpenInference span."""
+
+    trace_id: str
+    span_id: str
+    name: str
+    start_time: datetime
+    end_time: datetime
+    parent_span_id: Optional[str] = None
+    kind: Optional[str] = None
+    status_code: Optional[str] = None
+    status_message: Optional[str] = None
+    attributes: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.trace_id:
+            raise ValueError("trace_id must be provided")
+        if not self.span_id:
+            raise ValueError("span_id must be provided")
+        if self.end_time < self.start_time:
+            raise ValueError("span end_time cannot be earlier than start_time")
+        self.start_time = _ensure_utc(self.start_time)
+        self.end_time = _ensure_utc(self.end_time)
+
+    @property
+    def duration_ms(self) -> float:
+        """Return the span duration in milliseconds."""
+        delta = self.end_time - self.start_time
+        return delta.total_seconds() * 1000
+
+
+@dataclass(slots=True)
+class EvaluationMetric:
+    """A single evaluation metric tied to a trace or span."""
+
+    evaluation_name: str
+    metric_name: str
+    value: float
+    trace_id: str
+    timestamp: datetime
+    span_id: Optional[str] = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.evaluation_name:
+            raise ValueError("evaluation_name must be provided")
+        if not self.metric_name:
+            raise ValueError("metric_name must be provided")
+        if not isinstance(self.value, (int, float)):
+            raise TypeError("value must be numeric")
+        if not self.trace_id:
+            raise ValueError("trace_id must be provided")
+        self.timestamp = _ensure_utc(self.timestamp)
+
+
+@dataclass(slots=True)
+class TelemetryBatch:
+    """Bundle of telemetry destined for Phoenix."""
+
+    dataset: Dataset
+    traces: List[TraceSpan] = field(default_factory=list)
+    evaluations: List[EvaluationMetric] = field(default_factory=list)
+
+    def iter_spans(self) -> Iterable[TraceSpan]:
+        return iter(self.traces)
+
+    def iter_evaluations(self) -> Iterable[EvaluationMetric]:
+        return iter(self.evaluations)

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from op_observe.dashboards import phoenix
+
+
+def test_default_dashboards_structure() -> None:
+    dashboards = phoenix.default_dashboards()
+    assert len(dashboards) == 2
+
+    overview, evaluation = dashboards
+    assert overview.title == "Phoenix Trace Observatory"
+    assert len(overview.panels) == 3
+    assert overview.panels[0].query.startswith("SELECT $__timeGroupAlias")
+
+    evaluation_queries = [panel.query for panel in evaluation.panels]
+    assert any("evaluation_results" in query for query in evaluation_queries)
+    assert evaluation.title == "Phoenix Evaluation Monitor"
+
+
+def test_iter_dashboard_dicts_serialises() -> None:
+    payloads = list(phoenix.iter_dashboard_dicts())
+    assert len(payloads) == 2
+    first_panel = payloads[0]["panels"][0]
+    assert {"title", "query"}.issubset(first_panel.keys())

--- a/tests/test_phoenix_client.py
+++ b/tests/test_phoenix_client.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from op_observe.phoenix.client import EvaluationResult, PhoenixClient
+from op_observe.telemetry.models import Dataset
+
+
+def test_register_dataset_caches_response() -> None:
+    calls = []
+
+    def transport(method: str, path: str, payload: dict) -> dict:
+        calls.append((method, path, payload))
+        assert method == "POST"
+        assert path == "/v1/datasets"
+        assert payload["name"] == "test-dataset"
+        return {"dataset_id": "ds-123"}
+
+    client = PhoenixClient("http://phoenix", transport=transport)
+    dataset = Dataset(name="test-dataset", schema={"input": "text"}, metadata={"env": "dev"})
+
+    assert client.register_dataset(dataset) == "ds-123"
+    assert client.register_dataset(dataset) == "ds-123"
+    assert len(calls) == 1
+    assert client.dataset_registered("test-dataset")
+
+
+def test_update_evaluation_payload() -> None:
+    recorded = []
+
+    def transport(method: str, path: str, payload: dict) -> dict:
+        recorded.append((method, path, payload))
+        return {"status": "ok"}
+
+    client = PhoenixClient("http://phoenix", transport=transport)
+
+    result = EvaluationResult(
+        record_id="trace-1",
+        trace_id="trace-1",
+        span_id="span-1",
+        metrics={"accuracy": 0.9},
+        metadata={"label": "A"},
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    response = client.update_evaluation("ds-1", "retrieval", [result])
+    assert recorded[0][0] == "POST"
+    assert recorded[0][1] == "/v1/datasets/ds-1/evaluations/retrieval"
+    payload = recorded[0][2]
+    assert payload["dataset_id"] == "ds-1"
+    assert payload["results"][0]["record_id"] == "trace-1"
+    assert payload["results"][0]["metadata"]["label"] == "A"
+    assert response == {"status": "ok"}
+
+
+def test_update_evaluation_skips_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    def failing_transport(method: str, path: str, payload: dict) -> dict:  # pragma: no cover - should not be called
+        raise AssertionError("transport should not be called for empty results")
+
+    client = PhoenixClient("http://phoenix", transport=failing_transport)
+    assert client.update_evaluation("ds-1", "eval", []) == {}
+
+
+def test_log_spans_skips_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    def failing_transport(method: str, path: str, payload: dict) -> dict:  # pragma: no cover - should not be called
+        raise AssertionError("transport should not be called for empty spans")
+
+    client = PhoenixClient("http://phoenix", transport=failing_transport)
+    assert client.log_spans("ds-1", []) == {}

--- a/tests/test_phoenix_exporter.py
+++ b/tests/test_phoenix_exporter.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from op_observe.phoenix.client import PhoenixClient
+from op_observe.phoenix.exporter import PhoenixExporter
+from op_observe.telemetry.models import Dataset, EvaluationMetric, TelemetryBatch, TraceSpan
+
+
+def test_export_batch_exports_traces_and_evaluations() -> None:
+    requests: list[tuple[str, str, dict]] = []
+
+    def transport(method: str, path: str, payload: dict) -> dict:
+        requests.append((method, path, payload))
+        if path == "/v1/datasets":
+            return {"dataset_id": "dataset-xyz"}
+        return {"status": "ok"}
+
+    client = PhoenixClient("http://phoenix", transport=transport)
+    exporter = PhoenixExporter(client)
+
+    dataset = Dataset(name="observability", schema={"input": "text", "output": "text"})
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    span = TraceSpan(
+        trace_id="trace-1",
+        span_id="span-1",
+        name="llm.invoke",
+        start_time=start,
+        end_time=start + timedelta(seconds=1),
+        parent_span_id=None,
+        kind="LLM",
+        status_code="OK",
+        attributes={
+            "openinference.prompt": "hello",
+            "openinference.response": "world",
+            "guardrail.verdict": "pass",
+            "tenant": "acme",
+        },
+    )
+
+    metrics = [
+        EvaluationMetric(
+            evaluation_name="llm_critic",
+            metric_name="score",
+            value=0.82,
+            trace_id="trace-1",
+            span_id="span-1",
+            timestamp=start + timedelta(seconds=2),
+            metadata={"record_id": "trace-1", "label": "good"},
+        ),
+        EvaluationMetric(
+            evaluation_name="llm_critic",
+            metric_name="pass",
+            value=1.0,
+            trace_id="trace-1",
+            span_id="span-1",
+            timestamp=start + timedelta(seconds=3),
+            metadata={"record_id": "trace-1", "threshold": 0.7},
+        ),
+        EvaluationMetric(
+            evaluation_name="retrieval_quality",
+            metric_name="hit_rate",
+            value=0.9,
+            trace_id="trace-2",
+            span_id="span-2",
+            timestamp=start + timedelta(seconds=4),
+            metadata={},
+        ),
+    ]
+
+    batch = TelemetryBatch(dataset=dataset, traces=[span], evaluations=metrics)
+
+    dataset_id = exporter.export_batch(batch)
+    assert dataset_id == "dataset-xyz"
+
+    assert [path for _, path, _ in requests][:1] == ["/v1/datasets"]
+
+    span_request = next(payload for method, path, payload in requests if path.endswith("/spans"))
+    spans_payload = span_request["spans"]
+    assert spans_payload[0]["trace_id"] == "trace-1"
+    assert spans_payload[0]["open_inference"]["prompt"] == "hello"
+    assert spans_payload[0]["attributes"]["tenant"] == "acme"
+
+    evaluation_requests = {
+        path: payload for method, path, payload in requests if "/evaluations/" in path
+    }
+    critic_payload = evaluation_requests["/v1/datasets/dataset-xyz/evaluations/llm_critic"]
+    critic_results = critic_payload["results"][0]
+    assert critic_results["metrics"] == {"score": 0.82, "pass": 1.0}
+    assert critic_results["metadata"] == {"label": "good", "threshold": 0.7}
+    assert critic_results["span_id"] == "span-1"
+
+    retrieval_payload = evaluation_requests["/v1/datasets/dataset-xyz/evaluations/retrieval_quality"]
+    assert retrieval_payload["results"][0]["metrics"]["hit_rate"] == 0.9


### PR DESCRIPTION
## Summary
- add Phoenix client and exporter to register datasets, send spans, and update evaluations from telemetry batches
- define telemetry dataclasses plus Phoenix dashboard specifications for traces and evaluations
- configure packaging and provide unit tests covering exporter logic, client behaviour, and dashboard payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b747ce44832bb9dff74c537c4665