### PR TITLE
Implement retrieval pipeline with in-memory Qdrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# OP-Observe Retrieval Pipeline
+
+This package implements a retrieval pipeline for OP-Observe with an in-memory Qdrant-compatible
+vector store, ONNX Runtime and vLLM embedding integrations, HNSW-inspired indexing, query caching,
+and optional reranking.
+
+The unit tests exercise ingestion, retrieval, caching, and latency guarantees, while the benchmark
+test ensures sub-200ms search performance for typical workloads.

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,0 +1,23 @@
+"""OP-Observe retrieval pipeline package."""
+
+from .models import Document, QueryResponse, SearchResult
+from .retrieval import RetrievalPipeline
+from .vector_store.qdrant import LocalQdrantClient, QdrantVectorStore
+from .embeddings.base import BaseEmbedder
+from .embeddings.onnx import OnnxEmbedder
+from .embeddings.vllm import VLLMEmbedder
+from .rerankers import BaseReranker, DotProductReranker
+
+__all__ = [
+    "Document",
+    "QueryResponse",
+    "SearchResult",
+    "RetrievalPipeline",
+    "LocalQdrantClient",
+    "QdrantVectorStore",
+    "BaseEmbedder",
+    "OnnxEmbedder",
+    "VLLMEmbedder",
+    "BaseReranker",
+    "DotProductReranker",
+]

--- a/op_observe/embeddings/base.py
+++ b/op_observe/embeddings/base.py
@@ -1,0 +1,50 @@
+"""Interfaces and helpers for embedding providers."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, List
+
+from ..models import Vector
+
+
+class BaseEmbedder(ABC):
+    """Common interface implemented by embedding backends."""
+
+    @property
+    @abstractmethod
+    def dimension(self) -> int:
+        """Return the dimensionality of vectors produced by the embedder."""
+
+    @abstractmethod
+    def embed(self, text: str) -> Vector:
+        """Generate an embedding for the provided text."""
+
+    def embed_batch(self, texts: Iterable[str]) -> List[Vector]:
+        """Embed a batch of texts."""
+
+        return [self.embed(text) for text in texts]
+
+
+class CachedEmbedder(BaseEmbedder):
+    """Decorator that adds LRU caching to another embedder."""
+
+    def __init__(self, inner: BaseEmbedder, maxsize: int = 256):
+        from ..utils import LRUCache
+
+        self._inner = inner
+        self._cache = LRUCache[List[float]](maxsize=maxsize)
+
+    @property
+    def dimension(self) -> int:
+        return self._inner.dimension
+
+    def embed(self, text: str) -> Vector:
+        cached = self._cache.get(text)
+        if cached is not None:
+            return list(cached)
+        vector = self._inner.embed(text)
+        self._cache.put(text, list(vector))
+        return vector
+
+    def embed_batch(self, texts: Iterable[str]) -> List[Vector]:
+        return [self.embed(text) for text in texts]

--- a/op_observe/embeddings/onnx.py
+++ b/op_observe/embeddings/onnx.py
@@ -1,0 +1,45 @@
+"""ONNX Runtime embedding backend."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+from .base import BaseEmbedder
+from ..models import Vector, ensure_vector
+
+try:
+    import onnxruntime as ort  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    ort = None  # type: ignore
+
+
+class OnnxEmbedder(BaseEmbedder):
+    """Embed texts using an ONNX model via ONNX Runtime."""
+
+    def __init__(self, model_path: str | Path, input_name: str, output_name: str):
+        if ort is None:  # pragma: no cover - environment dependent
+            raise RuntimeError("onnxruntime is not installed")
+        self._session = ort.InferenceSession(str(model_path))  # type: ignore[attr-defined]
+        self._input_name = input_name
+        self._output_name = output_name
+        self._dimension = self._infer_dimension()
+
+    def _infer_dimension(self) -> int:
+        dummy_text = ""
+        vector = self.embed(dummy_text)
+        return len(vector)
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def embed(self, text: str) -> Vector:
+        inputs = {self._input_name: [text]}
+        outputs = self._session.run([self._output_name], inputs)
+        vector = outputs[0][0]
+        return ensure_vector(vector)
+
+    def embed_batch(self, texts: Iterable[str]) -> List[Vector]:
+        inputs = {self._input_name: list(texts)}
+        outputs = self._session.run([self._output_name], inputs)
+        return [ensure_vector(vector) for vector in outputs[0]]

--- a/op_observe/embeddings/vllm.py
+++ b/op_observe/embeddings/vllm.py
@@ -1,0 +1,73 @@
+"""vLLM embedding backend using an OpenAI-compatible HTTP endpoint."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, MutableMapping, Optional
+
+from .base import BaseEmbedder
+from ..models import Vector, ensure_vector
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - optional dependency
+    requests = None  # type: ignore
+
+
+@dataclass
+class VLLMConfig:
+    endpoint: str
+    model: str
+    api_key: Optional[str] = None
+    timeout: float = 10.0
+    headers: Optional[Mapping[str, str]] = None
+
+
+class VLLMEmbedder(BaseEmbedder):
+    """Call a vLLM server that exposes the OpenAI embeddings API."""
+
+    def __init__(self, config: VLLMConfig):
+        if requests is None:  # pragma: no cover - environment dependent
+            raise RuntimeError("requests is required for the vLLM embedder")
+        self._config = config
+        self._dimension = None
+
+    @property
+    def dimension(self) -> int:
+        if self._dimension is None:  # pragma: no cover - network dependent
+            vector = self.embed("")
+            self._dimension = len(vector)
+        return self._dimension
+
+    def _headers(self) -> MutableMapping[str, str]:
+        headers: MutableMapping[str, str] = {"Content-Type": "application/json"}
+        if self._config.headers:
+            headers.update(dict(self._config.headers))
+        if self._config.api_key:
+            headers.setdefault("Authorization", f"Bearer {self._config.api_key}")
+        return headers
+
+    def embed(self, text: str) -> Vector:
+        payload = {"input": [text], "model": self._config.model}
+        response = requests.post(  # type: ignore[operator]
+            self._config.endpoint,
+            data=json.dumps(payload),
+            headers=self._headers(),
+            timeout=self._config.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        vector = data["data"][0]["embedding"]
+        return ensure_vector(vector)
+
+    def embed_batch(self, texts: Iterable[str]) -> List[Vector]:
+        payload = {"input": list(texts), "model": self._config.model}
+        response = requests.post(  # type: ignore[operator]
+            self._config.endpoint,
+            data=json.dumps(payload),
+            headers=self._headers(),
+            timeout=self._config.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return [ensure_vector(item["embedding"]) for item in data["data"]]

--- a/op_observe/models.py
+++ b/op_observe/models.py
@@ -1,0 +1,70 @@
+"""Common dataclasses used across the retrieval pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+Vector = List[float]
+
+
+@dataclass(slots=True)
+class Document:
+    """Container for ingested documents."""
+
+    doc_id: str
+    text: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_payload(self) -> Dict[str, Any]:
+        """Return a mutable payload for storage in the vector index."""
+
+        payload: Dict[str, Any] = dict(self.metadata)
+        payload.setdefault("text", self.text)
+        payload.setdefault("doc_id", self.doc_id)
+        return payload
+
+
+@dataclass(slots=True)
+class VectorRecord:
+    """Representation of a stored vector."""
+
+    point_id: str
+    vector: Vector
+    payload: MutableMapping[str, Any]
+
+
+@dataclass(slots=True)
+class VectorMatch:
+    """Result entry produced by vector store searches."""
+
+    point_id: str
+    score: float
+    payload: Mapping[str, Any]
+    vector: Vector
+
+
+@dataclass(slots=True)
+class SearchResult:
+    """Pipeline-friendly search result."""
+
+    doc_id: str
+    score: float
+    text: str
+    metadata: Mapping[str, Any]
+
+
+@dataclass(slots=True)
+class QueryResponse:
+    """Container for query responses."""
+
+    results: List[SearchResult]
+    latency_ms: float
+    cached: bool
+    used_reranker: bool
+
+
+def ensure_vector(vector: Iterable[float]) -> Vector:
+    """Normalize an iterable of floats to a list."""
+
+    return [float(x) for x in vector]

--- a/op_observe/rerankers.py
+++ b/op_observe/rerankers.py
@@ -1,0 +1,39 @@
+"""Reranking utilities."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, List
+
+from .models import VectorMatch
+from .utils import cosine_similarity
+
+
+class BaseReranker(ABC):
+    """Base interface for rerankers."""
+
+    @abstractmethod
+    def rerank(
+        self,
+        query: str,
+        query_vector: Iterable[float],
+        candidates: List[VectorMatch],
+    ) -> List[VectorMatch]:
+        """Return the reranked candidates."""
+
+
+class DotProductReranker(BaseReranker):
+    """Simple reranker that sorts by cosine similarity to the query vector."""
+
+    def rerank(
+        self,
+        query: str,
+        query_vector: Iterable[float],
+        candidates: List[VectorMatch],
+    ) -> List[VectorMatch]:
+        query_vector_list = list(query_vector)
+        scored = [
+            (cosine_similarity(query_vector_list, match.vector), match)
+            for match in candidates
+        ]
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [match for _, match in scored]

--- a/op_observe/retrieval.py
+++ b/op_observe/retrieval.py
@@ -1,0 +1,91 @@
+"""Retrieval pipeline built around the Qdrant vector store."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+from .embeddings.base import BaseEmbedder, CachedEmbedder
+from .models import Document, QueryResponse, SearchResult, VectorMatch, VectorRecord
+from .rerankers import BaseReranker
+from .utils import LRUCache
+from .vector_store.qdrant import QdrantVectorStore
+
+
+@dataclass
+class RetrievalConfig:
+    collection_name: str = "documents"
+    cache_size: int = 128
+    latency_budget_ms: float = 200.0
+    use_reranker: bool = False
+    ef_search: int = 32
+
+
+class RetrievalPipeline:
+    """High-level orchestration of embeddings, ingestion, and search."""
+
+    def __init__(
+        self,
+        embedder: BaseEmbedder,
+        vector_store: QdrantVectorStore,
+        reranker: BaseReranker | None = None,
+        config: RetrievalConfig | None = None,
+        cache_embeddings: bool = True,
+    ) -> None:
+        self._base_embedder = embedder
+        self.embedder = CachedEmbedder(embedder) if cache_embeddings else embedder
+        self.vector_store = vector_store
+        self.reranker = reranker
+        self.config = config or RetrievalConfig(collection_name=vector_store.collection_name)
+        self._search_cache: LRUCache[QueryResponse] = LRUCache(self.config.cache_size)
+
+    @property
+    def dimension(self) -> int:
+        return self.embedder.dimension
+
+    def ingest_documents(self, documents: Iterable[Document]) -> None:
+        records = []
+        for document in documents:
+            vector = self.embedder.embed(document.text)
+            payload = document.as_payload()
+            records.append(VectorRecord(document.doc_id, vector, payload))
+        self.vector_store.upsert_documents(records)
+        self._search_cache.clear()
+
+    def ingest_texts(self, texts: Iterable[str]) -> None:
+        documents = [Document(str(index), text) for index, text in enumerate(texts)]
+        self.ingest_documents(documents)
+
+    def search(self, query: str, top_k: int = 5) -> QueryResponse:
+        cached = self._search_cache.get(query)
+        if cached is not None:
+            return QueryResponse(
+                results=[result for result in cached.results],
+                latency_ms=cached.latency_ms,
+                cached=True,
+                used_reranker=cached.used_reranker,
+            )
+        start = time.perf_counter()
+        query_vector = self.embedder.embed(query)
+        matches = self.vector_store.search(query_vector, top_k)
+        if self.config.use_reranker and self.reranker is not None:
+            matches = self.reranker.rerank(query, query_vector, matches)
+            used_reranker = True
+        else:
+            used_reranker = False
+        results = [self._to_search_result(match) for match in matches[:top_k]]
+        latency_ms = (time.perf_counter() - start) * 1000.0
+        response = QueryResponse(results=results, latency_ms=latency_ms, cached=False, used_reranker=used_reranker)
+        if latency_ms <= self.config.latency_budget_ms:
+            self._search_cache.put(query, response)
+        return response
+
+    def _to_search_result(self, match: VectorMatch) -> SearchResult:
+        payload = dict(match.payload)
+        text = payload.get("text", "")
+        metadata = {key: value for key, value in payload.items() if key not in {"text"}}
+        metadata.setdefault("doc_id", payload.get("doc_id", match.point_id))
+        return SearchResult(doc_id=payload.get("doc_id", match.point_id), score=match.score, text=text, metadata=metadata)
+
+    def clear_cache(self) -> None:
+        self._search_cache.clear()

--- a/op_observe/utils.py
+++ b/op_observe/utils.py
@@ -1,0 +1,63 @@
+"""Utility helpers for vector operations and caches."""
+from __future__ import annotations
+
+import math
+from collections import OrderedDict
+from typing import Generic, Iterable, Tuple, TypeVar
+
+from .models import Vector
+
+T = TypeVar("T")
+
+
+def dot_product(a: Vector, b: Vector) -> float:
+    if len(a) != len(b):
+        raise ValueError("Vectors must share the same dimensionality")
+    return sum(x * y for x, y in zip(a, b))
+
+
+def l2_norm(vector: Vector) -> float:
+    return math.sqrt(sum(x * x for x in vector))
+
+
+def cosine_similarity(a: Vector, b: Vector) -> float:
+    denom = l2_norm(a) * l2_norm(b)
+    if denom == 0:
+        return 0.0
+    return dot_product(a, b) / denom
+
+
+def l2_distance(a: Vector, b: Vector) -> float:
+    if len(a) != len(b):
+        raise ValueError("Vectors must share the same dimensionality")
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+class LRUCache(OrderedDict[str, T], Generic[T]):
+    """Minimal LRU cache for predictable behaviour in tests."""
+
+    def __init__(self, maxsize: int):
+        super().__init__()
+        if maxsize <= 0:
+            raise ValueError("maxsize must be positive")
+        self.maxsize = maxsize
+
+    def get(self, key: str) -> T | None:  # type: ignore[override]
+        if key not in self:
+            return None
+        value = super().pop(key)
+        super().__setitem__(key, value)
+        return value
+
+    def put(self, key: str, value: T) -> None:
+        if key in self:
+            super().pop(key)
+        elif len(self) >= self.maxsize:
+            self.popitem(last=False)
+        super().__setitem__(key, value)
+
+
+class TimedCache(LRUCache[Tuple[T, float]]):
+    """LRU cache storing (value, latency) tuples."""
+
+    pass

--- a/op_observe/vector_store/hnsw.py
+++ b/op_observe/vector_store/hnsw.py
@@ -1,0 +1,125 @@
+"""Lightweight HNSW-inspired index for unit testing."""
+from __future__ import annotations
+
+import heapq
+from typing import Dict, List, Optional, Set, Tuple
+
+from ..models import Vector
+from ..utils import cosine_similarity
+
+
+class HnswIndex:
+    """A minimal HNSW-inspired graph index.
+
+    The implementation focuses on deterministic behaviour suited for tests while
+    still mimicking the greedy search behaviour of HNSW graphs.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        m: int = 16,
+        ef_search: int = 32,
+    ) -> None:
+        if dim <= 0:
+            raise ValueError("dim must be positive")
+        if m <= 0:
+            raise ValueError("m must be positive")
+        if ef_search <= 0:
+            raise ValueError("ef_search must be positive")
+        self.dim = dim
+        self.m = m
+        self.ef_search = max(ef_search, m)
+        self._vectors: Dict[str, Vector] = {}
+        self._graph: Dict[str, Set[str]] = {}
+        self._entrypoint: Optional[str] = None
+
+    def __len__(self) -> int:
+        return len(self._vectors)
+
+    def add_point(self, point_id: str, vector: Vector) -> None:
+        if len(vector) != self.dim:
+            raise ValueError("vector dimensionality mismatch")
+        self._vectors[point_id] = list(vector)
+        self._graph.setdefault(point_id, set())
+        if self._entrypoint is None:
+            self._entrypoint = point_id
+            return
+        neighbors = self._select_neighbors(point_id, vector)
+        for neighbor_id in neighbors:
+            self._graph[point_id].add(neighbor_id)
+            self._graph.setdefault(neighbor_id, set()).add(point_id)
+            self._trim(neighbor_id)
+        self._trim(point_id)
+
+    def update_point(self, point_id: str, vector: Vector) -> None:
+        if point_id not in self._vectors:
+            raise KeyError(point_id)
+        if len(vector) != self.dim:
+            raise ValueError("vector dimensionality mismatch")
+        self._vectors[point_id] = list(vector)
+
+    def _select_neighbors(self, point_id: str, vector: Vector) -> List[str]:
+        scored: List[Tuple[float, str]] = []
+        for other_id, other_vector in self._vectors.items():
+            if other_id == point_id:
+                continue
+            score = cosine_similarity(vector, other_vector)
+            scored.append((score, other_id))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [point for _, point in scored[: self.m]]
+
+    def _trim(self, point_id: str) -> None:
+        neighbors = self._graph.get(point_id)
+        if not neighbors:
+            return
+        if len(neighbors) <= self.m:
+            return
+        vector = self._vectors[point_id]
+        scored = [
+            (cosine_similarity(vector, self._vectors[neighbor]), neighbor)
+            for neighbor in neighbors
+        ]
+        scored.sort(key=lambda item: item[0], reverse=True)
+        keep = {neighbor for _, neighbor in scored[: self.m]}
+        self._graph[point_id] = keep
+
+    def search(self, query: Vector, top_k: int) -> List[Tuple[str, float]]:
+        if len(query) != self.dim:
+            raise ValueError("vector dimensionality mismatch")
+        if not self._vectors:
+            return []
+        entrypoint = self._entrypoint
+        assert entrypoint is not None
+        visited: Set[str] = set()
+        candidate_heap: List[Tuple[float, str]] = []
+        best_heap: List[Tuple[float, str]] = []
+        entry_score = cosine_similarity(query, self._vectors[entrypoint])
+        heapq.heappush(candidate_heap, (-entry_score, entrypoint))
+        self._push(best_heap, (entry_score, entrypoint), self.ef_search)
+        while candidate_heap and len(visited) < self.ef_search:
+            score_neg, current = heapq.heappop(candidate_heap)
+            score = -score_neg
+            if current in visited:
+                continue
+            visited.add(current)
+            current_vector = self._vectors[current]
+            for neighbor in self._graph.get(current, set()) | {current}:
+                if neighbor in visited:
+                    continue
+                neighbor_vector = self._vectors[neighbor]
+                neighbor_score = cosine_similarity(query, neighbor_vector)
+                heapq.heappush(candidate_heap, (-neighbor_score, neighbor))
+                self._push(best_heap, (neighbor_score, neighbor), self.ef_search)
+        best_heap.sort(key=lambda item: item[0], reverse=True)
+        ordered = best_heap[:top_k]
+        return [(point_id, score) for score, point_id in ordered]
+
+    @staticmethod
+    def _push(heap: List[Tuple[float, str]], item: Tuple[float, str], maxsize: int) -> None:
+        if len(heap) < maxsize:
+            heap.append(item)
+            return
+        heap.sort(key=lambda entry: entry[0])
+        if item[0] > heap[0][0]:
+            heap[0] = item

--- a/op_observe/vector_store/qdrant.py
+++ b/op_observe/vector_store/qdrant.py
@@ -1,0 +1,84 @@
+"""In-memory Qdrant-compatible vector store used for tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, MutableMapping
+
+from ..models import Vector, VectorMatch, VectorRecord
+from .hnsw import HnswIndex
+
+
+@dataclass
+class CollectionConfig:
+    name: str
+    vector_size: int
+    m: int = 16
+    ef_search: int = 32
+
+
+class LocalQdrantClient:
+    """Simple in-memory substitute for the Qdrant client."""
+
+    def __init__(self) -> None:
+        self._collections: MutableMapping[str, HnswIndex] = {}
+        self._payloads: MutableMapping[str, MutableMapping[str, MutableMapping[str, object]]] = {}
+
+    def recreate_collection(self, collection_name: str, config: CollectionConfig) -> None:
+        self._collections[collection_name] = HnswIndex(
+            dim=config.vector_size,
+            m=config.m,
+            ef_search=config.ef_search,
+        )
+        self._payloads[collection_name] = {}
+
+    def upsert(self, collection_name: str, records: Iterable[VectorRecord]) -> None:
+        index = self._collections[collection_name]
+        payload_store = self._payloads[collection_name]
+        for record in records:
+            payload_store[record.point_id] = dict(record.payload)
+            if record.point_id in index._vectors:
+                index.update_point(record.point_id, record.vector)
+            else:
+                index.add_point(record.point_id, record.vector)
+
+    def search(self, collection_name: str, vector: Vector, top_k: int) -> List[VectorMatch]:
+        index = self._collections[collection_name]
+        payload_store = self._payloads[collection_name]
+        matches = index.search(vector, top_k)
+        results = [
+            VectorMatch(
+                point_id=point_id,
+                score=score,
+                payload=dict(payload_store[point_id]),
+                vector=list(index._vectors[point_id]),
+            )
+            for point_id, score in matches
+        ]
+        return results
+
+
+class QdrantVectorStore:
+    """Facade over :class:`LocalQdrantClient` for ingestion and search."""
+
+    def __init__(
+        self,
+        client: LocalQdrantClient,
+        collection_name: str,
+        vector_size: int,
+        m: int = 16,
+        ef_search: int = 32,
+    ) -> None:
+        self.client = client
+        self.collection_name = collection_name
+        self.config = CollectionConfig(collection_name, vector_size, m=m, ef_search=ef_search)
+        self.client.recreate_collection(collection_name, self.config)
+
+    def upsert_documents(self, records: Iterable[VectorRecord]) -> None:
+        self.client.upsert(self.collection_name, records)
+
+    def search(self, vector: Vector, top_k: int) -> List[VectorMatch]:
+        return self.client.search(self.collection_name, vector, top_k)
+
+    def __len__(self) -> int:
+        index = self.client._collections[self.collection_name]
+        return len(index)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "op-observe"
+version = "0.1.0"
+description = "OP-Observe retrieval pipeline utilities"
+authors = [
+  { name = "OP Observe" }
+]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+onnx = ["onnxruntime"]
+vllm = ["requests"]
+qdrant = ["qdrant-client>=1.7.0"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = [
+  "tests"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from op_observe.embeddings.base import BaseEmbedder
+from op_observe.retrieval import RetrievalConfig, RetrievalPipeline
+from op_observe.rerankers import DotProductReranker
+from op_observe.vector_store.qdrant import LocalQdrantClient, QdrantVectorStore
+
+
+class DeterministicEmbedder(BaseEmbedder):
+    def __init__(self, dimension: int = 8):
+        self._dimension = dimension
+        self.calls = 0
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def embed(self, text: str):
+        self.calls += 1
+        vector = [0.0 for _ in range(self._dimension)]
+        text_lower = text.lower()
+        tokens = text_lower.split()
+        if not tokens:
+            return vector
+        for token in tokens:
+            bucket = sum(ord(char) for char in token) % self._dimension
+            vector[bucket] += 1.0
+        return vector
+
+    def embed_batch(self, texts: Iterable[str]):
+        return [self.embed(text) for text in texts]
+
+
+@dataclass
+class PipelineFixture:
+    embedder: DeterministicEmbedder
+    pipeline: RetrievalPipeline
+
+
+def build_pipeline(use_reranker: bool = False, cache_size: int = 16) -> PipelineFixture:
+    embedder = DeterministicEmbedder()
+    client = LocalQdrantClient()
+    store = QdrantVectorStore(client, "test", embedder.dimension)
+    config = RetrievalConfig(use_reranker=use_reranker, cache_size=cache_size)
+    reranker = DotProductReranker() if use_reranker else None
+    pipeline = RetrievalPipeline(embedder, store, reranker=reranker, config=config)
+    return PipelineFixture(embedder=embedder, pipeline=pipeline)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from statistics import mean
+
+from .conftest import build_pipeline
+
+
+def test_search_latency_stays_under_budget():
+    fixture = build_pipeline()
+    corpus = [f"document {i} body text" for i in range(64)]
+    fixture.pipeline.ingest_texts(corpus)
+
+    latencies = []
+    for idx in range(10):
+        query = f"document {idx}"
+        response = fixture.pipeline.search(query)
+        latencies.append(response.latency_ms)
+        assert response.latency_ms < 200
+        assert not response.cached
+
+    assert mean(latencies) < 200

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from op_observe.models import Document
+from .conftest import build_pipeline
+
+
+def test_ingest_and_search_returns_best_match():
+    fixture = build_pipeline()
+    docs = [
+        Document("a", "The quick brown fox"),
+        Document("b", "Jumps over the lazy dog"),
+        Document("c", "Retrieval augmented generation"),
+    ]
+    fixture.pipeline.ingest_documents(docs)
+
+    response = fixture.pipeline.search("quick fox", top_k=2)
+
+    assert response.results, "Expected at least one result"
+    best = response.results[0]
+    assert best.doc_id == "a"
+    assert "quick" in best.text
+    assert response.latency_ms < 200
+    assert not response.cached
+
+
+def test_search_uses_cache_and_avoids_recomputing_embeddings():
+    fixture = build_pipeline()
+    fixture.pipeline.ingest_texts(["alpha", "beta", "gamma"])
+
+    first = fixture.pipeline.search("alpha")
+    embed_calls_after_first = fixture.embedder.calls
+    second = fixture.pipeline.search("alpha")
+
+    assert second.cached is True
+    assert fixture.embedder.calls == embed_calls_after_first
+    assert first.results[0].doc_id == second.results[0].doc_id
+
+
+def test_cache_is_invalidated_on_new_ingest():
+    fixture = build_pipeline()
+    fixture.pipeline.ingest_texts(["alpha", "beta"])
+    fixture.pipeline.search("alpha")
+
+    fixture.pipeline.ingest_documents([Document("2", "alpha beta gamma")])
+    response = fixture.pipeline.search("alpha")
+
+    assert response.cached is False
+
+
+def test_optional_reranking_is_respected():
+    fixture = build_pipeline(use_reranker=True)
+    fixture.pipeline.ingest_texts(["zero", "one", "two"])
+
+    response = fixture.pipeline.search("two")
+
+    assert response.used_reranker is True
+    assert response.latency_ms < 200


### PR DESCRIPTION
## Summary
- add a retrieval pipeline that coordinates embedding generation, ingestion, caching, and optional reranking
- provide an in-memory Qdrant-compatible vector store with an HNSW-inspired index plus ONNX Runtime and vLLM embedding adapters
- cover ingestion, caching behaviour, reranking, and sub-200 ms latency with unit tests and a benchmark test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b73b4808832b9595bef360ff07f2