### PR TITLE
Add agentic radar CLI with evidence packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pytest_cache/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Agentic Radar CLI
+
+This repository implements a reference CLI for the Agentic Radar scanner. It can:
+
+* Parse agentic application manifests
+* Run detectors that flag tool inventory, MCP servers, and dependency vulnerabilities
+* Build JSON reports summarizing findings and scenario test results
+* Package evidence bundles with findings, logs, and trace identifiers
+
+Use `agentic-radar --help` for usage details.

--- a/agentic_radar/__init__.py
+++ b/agentic_radar/__init__.py
@@ -1,0 +1,32 @@
+"""Agentic Radar package."""
+
+from .models import (
+    AgentComponent,
+    Dependency,
+    MCPServer,
+    ParsedProject,
+    RadarFinding,
+    RadarReport,
+    ScenarioResult,
+    Tool,
+)
+from .runner import ScanConfig, ScanResult, TestConfig, TestResult, run_scan, run_test
+
+__all__ = [
+    "AgentComponent",
+    "Dependency",
+    "MCPServer",
+    "ParsedProject",
+    "RadarFinding",
+    "RadarReport",
+    "ScenarioResult",
+    "Tool",
+    "ScanConfig",
+    "ScanResult",
+    "TestConfig",
+    "TestResult",
+    "run_scan",
+    "run_test",
+]
+
+__version__ = "0.1.0"

--- a/agentic_radar/cli.py
+++ b/agentic_radar/cli.py
@@ -1,0 +1,225 @@
+"""Command line interface for Agentic Radar."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .evidence import create_evidence_pack
+from .runner import ScanConfig, TestConfig, run_scan, run_test
+
+
+class CLIError(Exception):
+    """Raised for CLI usage errors."""
+
+
+def _add_common_run_arguments(parser: argparse.ArgumentParser, *, default_output: str) -> None:
+    parser.add_argument("path", nargs="?", default=".", help="Project root to scan")
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        default=None,
+        help="Path to write the JSON report (defaults to project root)",
+    )
+    parser.add_argument(
+        "--object-store",
+        dest="object_store",
+        default=None,
+        help="Optional path to a directory-backed object store",
+    )
+    parser.add_argument(
+        "--trace-id",
+        dest="trace_ids",
+        action="append",
+        default=None,
+        help="Trace identifier to include in the report metadata (repeatable)",
+    )
+    parser.add_argument(
+        "--label",
+        dest="labels",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Attach metadata labels to the report",
+    )
+    parser.add_argument(
+        "--no-project-snapshot",
+        dest="include_snapshot",
+        action="store_false",
+        help="Skip embedding the project snapshot in the report",
+    )
+    parser.set_defaults(default_output=default_output)
+
+
+def _parse_labels(pairs: Optional[Iterable[str]]) -> Dict[str, str]:
+    metadata: Dict[str, str] = {}
+    if not pairs:
+        return metadata
+    for pair in pairs:
+        if "=" not in pair:
+            raise CLIError(f"Invalid label '{pair}', expected KEY=VALUE")
+        key, value = pair.split("=", 1)
+        metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def _resolve_output_path(root: Path, provided: Optional[str], default_filename: str) -> Path:
+    if provided:
+        return Path(provided)
+    return root / default_filename
+
+
+def _handle_scan(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    output_path = _resolve_output_path(root, args.output, args.default_output)
+    metadata = _parse_labels(args.labels)
+    config = ScanConfig(
+        root=root,
+        output_path=output_path,
+        object_store_path=Path(args.object_store) if args.object_store else None,
+        trace_ids=list(args.trace_ids or []),
+        metadata=metadata,
+        include_project_snapshot=args.include_snapshot,
+    )
+    result = run_scan(config)
+    _print_report_summary(result.report, output_path=result.output_path, stored_artifact=result.stored_artifact)
+    return 0
+
+
+def _handle_test(args: argparse.Namespace) -> int:
+    root = Path(args.path).resolve()
+    output_path = _resolve_output_path(root, args.output, args.default_output)
+    metadata = _parse_labels(args.labels)
+    config = TestConfig(
+        root=root,
+        output_path=output_path,
+        object_store_path=Path(args.object_store) if args.object_store else None,
+        trace_ids=list(args.trace_ids or []),
+        metadata=metadata,
+        include_project_snapshot=args.include_snapshot,
+        scenarios=list(args.scenarios or []),
+    )
+    result = run_test(config)
+    _print_report_summary(result.report, output_path=result.output_path, stored_artifact=result.stored_artifact)
+    _print_scenario_summary(result.scenario_results)
+    return 0
+
+
+def _handle_evidence_pack(args: argparse.Namespace) -> int:
+    if not args.findings:
+        raise CLIError("At least one --findings path must be provided")
+    findings_paths = [Path(path) for path in args.findings]
+    logs_path = Path(args.logs) if args.logs else None
+    output_path = Path(args.output) if args.output else None
+    result = create_evidence_pack(
+        findings_paths,
+        logs_path=logs_path,
+        trace_ids=list(args.trace_ids or []),
+        output_path=output_path,
+        object_store_path=Path(args.object_store) if args.object_store else None,
+    )
+    _print_evidence_summary(result)
+    return 0
+
+
+def _print_report_summary(report, *, output_path: Path, stored_artifact: Optional[Path]) -> None:
+    summary = report.summary.get("findings", {})
+    print(f"Report written to {output_path}")
+    print(f"Project: {report.project_name} | mode={report.mode}")
+    if report.trace_ids:
+        print(f"Trace IDs: {', '.join(report.trace_ids)}")
+    print("Findings summary:")
+    for severity in ["critical", "high", "medium", "low", "info", "unknown", "total"]:
+        if severity in summary:
+            print(f"  {severity}: {summary[severity]}")
+    if stored_artifact:
+        print(f"Stored artifact at {stored_artifact}")
+
+
+def _print_scenario_summary(scenarios) -> None:
+    if not scenarios:
+        return
+    print("Scenario results:")
+    for result in scenarios:
+        suffix = f" ({result.details})" if result.details else ""
+        print(f"  {result.name}: {result.status}{suffix}")
+
+
+def _print_evidence_summary(result) -> None:
+    print(f"Evidence pack created at {result.pack_path}")
+    findings_count = len(result.metadata.get("findings", []))
+    logs_count = len(result.metadata.get("logs", []))
+    print(f"Includes {findings_count} findings file(s) and {logs_count} log file(s)")
+    if result.metadata.get("trace_ids"):
+        print(f"Trace IDs: {', '.join(result.metadata['trace_ids'])}")
+    if result.stored_path:
+        print(f"Stored artifact at {result.stored_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agentic-radar", description="Agentic Radar CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    scan_parser = subparsers.add_parser("scan", help="Run a radar scan")
+    _add_common_run_arguments(scan_parser, default_output="agentic-radar-report.json")
+    scan_parser.set_defaults(handler=_handle_scan)
+
+    test_parser = subparsers.add_parser("test", help="Run radar adversarial tests")
+    _add_common_run_arguments(test_parser, default_output="agentic-radar-test-report.json")
+    test_parser.add_argument(
+        "--scenario",
+        dest="scenarios",
+        action="append",
+        default=None,
+        help="Scenario to execute (repeatable)",
+    )
+    test_parser.set_defaults(handler=_handle_test)
+
+    evidence_parser = subparsers.add_parser("evidence", help="Evidence bundle operations")
+    evidence_subparsers = evidence_parser.add_subparsers(dest="evidence_command")
+    pack_parser = evidence_subparsers.add_parser("pack", help="Create an evidence pack")
+    pack_parser.add_argument(
+        "--findings",
+        dest="findings",
+        action="append",
+        required=True,
+        help="Path to a findings JSON file (repeatable)",
+    )
+    pack_parser.add_argument("--logs", dest="logs", default=None, help="Path to logs directory or file")
+    pack_parser.add_argument(
+        "--trace-id",
+        dest="trace_ids",
+        action="append",
+        default=None,
+        help="Trace identifier to embed in the evidence pack",
+    )
+    pack_parser.add_argument("-o", "--output", dest="output", default=None, help="Destination zip path")
+    pack_parser.add_argument(
+        "--object-store",
+        dest="object_store",
+        default=None,
+        help="Optional path to store the evidence pack",
+    )
+    pack_parser.set_defaults(handler=_handle_evidence_pack)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "handler"):
+        parser.print_help()
+        return 1
+    try:
+        return args.handler(args)
+    except CLIError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agentic_radar/detectors.py
+++ b/agentic_radar/detectors.py
@@ -1,0 +1,163 @@
+"""Detectors for Agentic Radar findings."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .models import ParsedProject, RadarFinding
+
+
+class Detector:
+    """Base detector."""
+
+    name = "detector"
+
+    def run(self, project: ParsedProject) -> List[RadarFinding]:
+        raise NotImplementedError
+
+
+class ToolInventoryDetector(Detector):
+    """Ensure tool metadata is complete."""
+
+    name = "tool-inventory"
+
+    def run(self, project: ParsedProject) -> List[RadarFinding]:
+        findings: List[RadarFinding] = []
+        for tool in project.tools:
+            if not tool.version:
+                findings.append(
+                    RadarFinding(
+                        identifier=f"TOOL-NOVERSION::{tool.name}",
+                        title=f"Tool '{tool.name}' is missing a pinned version",
+                        severity="medium",
+                        description=(
+                            "Tools should be version pinned to ensure deterministic security reviews "
+                            "and facilitate patch management."
+                        ),
+                        owasp_llm=["LLM02"],
+                        owasp_agentic=["Agentic-Tooling"],
+                        subject=tool.name,
+                        remediation="Add an explicit version for the tool in the agent manifest.",
+                        detector=self.name,
+                        metadata={"source": tool.source},
+                    )
+                )
+            if tool.source and tool.source.startswith("http"):
+                findings.append(
+                    RadarFinding(
+                        identifier=f"TOOL-EXTERNAL::{tool.name}",
+                        title=f"Tool '{tool.name}' is sourced from an external endpoint",
+                        severity="low",
+                        description=(
+                            "External tool sources should be evaluated for supply-chain exposure and "
+                            "guarded with allow-lists or sandboxes."
+                        ),
+                        owasp_llm=["LLM06"],
+                        owasp_agentic=["Agentic-External-Tool"],
+                        subject=tool.name,
+                        remediation="Review the external tool source and enforce provenance controls.",
+                        detector=self.name,
+                        metadata={"source": tool.source},
+                    )
+                )
+        return findings
+
+
+class MCPDetector(Detector):
+    """Detect misconfigurations in MCP server definitions."""
+
+    name = "mcp-server"
+
+    def run(self, project: ParsedProject) -> List[RadarFinding]:
+        findings: List[RadarFinding] = []
+        for server in project.mcp_servers:
+            if not server.capabilities:
+                findings.append(
+                    RadarFinding(
+                        identifier=f"MCP-NOCAP::{server.name}",
+                        title=f"MCP server '{server.name}' does not declare capabilities",
+                        severity="medium",
+                        description=(
+                            "Declare explicit MCP capabilities to apply least privilege controls and "
+                            "map permissions to security policies."
+                        ),
+                        owasp_llm=["LLM08"],
+                        owasp_agentic=["Agentic-MCP-LeastPrivilege"],
+                        subject=server.name,
+                        remediation="Document the MCP server capabilities and enforce policy checks.",
+                        detector=self.name,
+                        metadata={"endpoint": server.endpoint},
+                    )
+                )
+            if server.auth_mode in (None, "anonymous", "none"):
+                findings.append(
+                    RadarFinding(
+                        identifier=f"MCP-NOAUTH::{server.name}",
+                        title=f"MCP server '{server.name}' has no authentication configured",
+                        severity="high",
+                        description=(
+                            "Unprotected MCP servers expose powerful automation capabilities. Use "
+                            "mutual authentication and scoped tokens."
+                        ),
+                        owasp_llm=["LLM04"],
+                        owasp_agentic=["Agentic-MCP-Hardening"],
+                        subject=server.name,
+                        remediation="Require authentication and audit access for the MCP server.",
+                        detector=self.name,
+                        metadata={"endpoint": server.endpoint, "auth_mode": server.auth_mode},
+                    )
+                )
+        return findings
+
+
+class VulnerabilityDetector(Detector):
+    """Emit findings for dependency vulnerabilities."""
+
+    name = "dependency-vulnerability"
+
+    severity_map = {
+        "critical": "critical",
+        "high": "high",
+        "medium": "medium",
+        "moderate": "medium",
+        "low": "low",
+    }
+
+    def run(self, project: ParsedProject) -> List[RadarFinding]:
+        findings: List[RadarFinding] = []
+        for dependency in project.dependencies:
+            for vulnerability in dependency.vulnerabilities:
+                severity = vulnerability.get("severity", "unknown").lower()
+                normalized = self.severity_map.get(severity, "unknown")
+                identifier = vulnerability.get("id") or vulnerability.get("cve") or f"VULN::{dependency.name}"
+                findings.append(
+                    RadarFinding(
+                        identifier=f"DEP-VULN::{dependency.name}::{identifier}",
+                        title=f"Dependency '{dependency.name}' has a known vulnerability",
+                        severity=normalized,
+                        description=vulnerability.get(
+                            "description",
+                            "Dependency vulnerability reported by upstream advisory feeds.",
+                        ),
+                        owasp_llm=["LLM06"],
+                        owasp_agentic=["Agentic-SupplyChain"],
+                        subject=dependency.name,
+                        remediation=vulnerability.get("fix_version"),
+                        detector=self.name,
+                        metadata={
+                            "id": identifier,
+                            "severity": severity,
+                            "fix_version": vulnerability.get("fix_version"),
+                        },
+                    )
+                )
+        return findings
+
+
+def run_detectors(project: ParsedProject, detectors: Iterable[Detector]) -> List[RadarFinding]:
+    """Run detectors and aggregate findings."""
+
+    findings: List[RadarFinding] = []
+    for detector in detectors:
+        findings.extend(detector.run(project))
+    return findings

--- a/agentic_radar/evidence.py
+++ b/agentic_radar/evidence.py
@@ -1,0 +1,101 @@
+"""Evidence packaging utilities."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .object_store import LocalObjectStore, ObjectStore
+
+
+@dataclass
+class EvidencePackResult:
+    """Result of creating an evidence pack."""
+
+    pack_path: Path
+    metadata: dict
+    stored_path: Optional[Path] = None
+
+
+class EvidencePackBuilder:
+    """Builds zip-based evidence packs combining findings and logs."""
+
+    def __init__(self, object_store: Optional[ObjectStore] = None) -> None:
+        self.object_store = object_store
+
+    def build(
+        self,
+        *,
+        findings_paths: Iterable[Path],
+        logs_path: Optional[Path] = None,
+        trace_ids: Optional[Iterable[str]] = None,
+        output_path: Optional[Path] = None,
+    ) -> EvidencePackResult:
+        findings_list = [Path(path) for path in findings_paths]
+        if not findings_list:
+            raise ValueError("At least one findings file must be provided")
+        for path in findings_list:
+            if not path.exists():
+                raise FileNotFoundError(f"Findings file '{path}' does not exist")
+
+        output_path = Path(output_path or (findings_list[0].parent / "evidence-pack.zip"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        metadata = {
+            "artifact_type": "agentic-radar-evidence",
+            "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "findings": [],
+            "logs": [],
+            "trace_ids": list(trace_ids or []),
+        }
+
+        with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for findings_path in findings_list:
+                arcname = f"findings/{findings_path.name}"
+                archive.write(findings_path, arcname)
+                metadata["findings"].append(arcname)
+
+            if logs_path is not None:
+                logs_path = Path(logs_path)
+                if logs_path.is_dir():
+                    for file_path in sorted(p for p in logs_path.rglob("*") if p.is_file()):
+                        arcname = f"logs/{file_path.relative_to(logs_path)}"
+                        archive.write(file_path, arcname)
+                        metadata["logs"].append(str(arcname))
+                elif logs_path.is_file():
+                    arcname = f"logs/{logs_path.name}"
+                    archive.write(logs_path, arcname)
+                    metadata["logs"].append(arcname)
+                else:
+                    raise FileNotFoundError(f"Logs path '{logs_path}' does not exist")
+
+            archive.writestr("metadata.json", json.dumps(metadata, indent=2))
+
+        stored_path: Optional[Path] = None
+        if self.object_store is not None:
+            destination_name = output_path.name
+            stored_path = self.object_store.put_file(output_path, destination_name=destination_name)
+
+        return EvidencePackResult(pack_path=output_path, metadata=metadata, stored_path=stored_path)
+
+
+def create_evidence_pack(
+    findings_paths: Iterable[Path],
+    *,
+    logs_path: Optional[Path] = None,
+    trace_ids: Optional[Iterable[str]] = None,
+    output_path: Optional[Path] = None,
+    object_store_path: Optional[Path] = None,
+) -> EvidencePackResult:
+    object_store = LocalObjectStore(object_store_path) if object_store_path else None
+    builder = EvidencePackBuilder(object_store=object_store)
+    return builder.build(
+        findings_paths=findings_paths,
+        logs_path=logs_path,
+        trace_ids=trace_ids,
+        output_path=output_path,
+    )

--- a/agentic_radar/models.py
+++ b/agentic_radar/models.py
@@ -1,0 +1,287 @@
+"""Data models for Agentic Radar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _now_utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class Tool:
+    """Representation of a tool used by an agent."""
+
+    name: str
+    version: Optional[str] = None
+    source: Optional[str] = None
+    scope: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "source": self.source,
+            "scope": self.scope,
+        }
+
+
+@dataclass
+class MCPServer:
+    """Representation of an MCP server referenced by the project."""
+
+    name: str
+    endpoint: str
+    capabilities: List[str] = field(default_factory=list)
+    auth_mode: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "endpoint": self.endpoint,
+            "capabilities": list(self.capabilities),
+            "auth_mode": self.auth_mode,
+        }
+
+
+@dataclass
+class Dependency:
+    """Dependency inventory item."""
+
+    name: str
+    version: Optional[str] = None
+    license: Optional[str] = None
+    vulnerabilities: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "license": self.license,
+            "vulnerabilities": list(self.vulnerabilities),
+        }
+
+
+@dataclass
+class AgentComponent:
+    """Agent component definition."""
+
+    name: str
+    description: Optional[str] = None
+    tools: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "tools": list(self.tools),
+        }
+
+
+@dataclass
+class ParsedProject:
+    """Parsed representation of a project."""
+
+    root: Path
+    project_name: str
+    agents: List[AgentComponent] = field(default_factory=list)
+    tools: List[Tool] = field(default_factory=list)
+    mcp_servers: List[MCPServer] = field(default_factory=list)
+    dependencies: List[Dependency] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "root": str(self.root),
+            "project_name": self.project_name,
+            "agents": [agent.to_dict() for agent in self.agents],
+            "tools": [tool.to_dict() for tool in self.tools],
+            "mcp_servers": [server.to_dict() for server in self.mcp_servers],
+            "dependencies": [dep.to_dict() for dep in self.dependencies],
+            "metadata": dict(self.metadata),
+        }
+
+
+def normalize_severity(value: str) -> str:
+    """Normalize severity strings to a canonical lowercase form."""
+
+    normalized = (value or "unknown").strip().lower()
+    if normalized in {"critical", "high", "medium", "low", "info"}:
+        return normalized
+    return "unknown"
+
+
+@dataclass
+class RadarFinding:
+    """Finding emitted by the radar detectors."""
+
+    identifier: str
+    title: str
+    severity: str
+    description: str
+    owasp_llm: List[str] = field(default_factory=list)
+    owasp_agentic: List[str] = field(default_factory=list)
+    subject: Optional[str] = None
+    remediation: Optional[str] = None
+    detector: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.identifier,
+            "title": self.title,
+            "severity": normalize_severity(self.severity),
+            "description": self.description,
+            "owasp_llm": list(self.owasp_llm),
+            "owasp_agentic": list(self.owasp_agentic),
+            "subject": self.subject,
+            "remediation": self.remediation,
+            "detector": self.detector,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class ScenarioResult:
+    """Outcome of a scenario-based radar test."""
+
+    name: str
+    status: str
+    details: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "details": self.details,
+        }
+
+
+@dataclass
+class RadarReport:
+    """Final report produced by the radar."""
+
+    project_name: str
+    mode: str
+    generated_at: str = field(default_factory=_now_utc_iso)
+    findings: List[RadarFinding] = field(default_factory=list)
+    parsed_project: Optional[ParsedProject] = None
+    summary: Dict[str, Any] = field(default_factory=dict)
+    trace_ids: List[str] = field(default_factory=list)
+    scenario_results: List[ScenarioResult] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        parsed = self.parsed_project.to_dict() if self.parsed_project else None
+        return {
+            "project_name": self.project_name,
+            "mode": self.mode,
+            "generated_at": self.generated_at,
+            "summary": dict(self.summary),
+            "findings": [finding.to_dict() for finding in self.findings],
+            "parsed_project": parsed,
+            "trace_ids": list(self.trace_ids),
+            "scenario_results": [result.to_dict() for result in self.scenario_results],
+            "metadata": dict(self.metadata),
+        }
+
+    def write_json(self, path: Path) -> None:
+        import json
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as file:
+            json.dump(self.to_dict(), file, indent=2)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "RadarReport":
+        findings = [
+            RadarFinding(
+                identifier=item.get("id", "unknown"),
+                title=item.get("title", ""),
+                severity=item.get("severity", "unknown"),
+                description=item.get("description", ""),
+                owasp_llm=item.get("owasp_llm", []),
+                owasp_agentic=item.get("owasp_agentic", []),
+                subject=item.get("subject"),
+                remediation=item.get("remediation"),
+                detector=item.get("detector"),
+                metadata=item.get("metadata", {}),
+            )
+            for item in payload.get("findings", [])
+        ]
+        scenario_results = [
+            ScenarioResult(
+                name=item.get("name", "unknown"),
+                status=item.get("status", "unknown"),
+                details=item.get("details"),
+            )
+            for item in payload.get("scenario_results", [])
+        ]
+        parsed_payload = payload.get("parsed_project")
+        parsed_project = None
+        if parsed_payload:
+            parsed_project = ParsedProject(
+                root=Path(parsed_payload.get("root", ".")),
+                project_name=parsed_payload.get("project_name", "unknown"),
+                agents=[
+                    AgentComponent(
+                        name=item.get("name", "unknown"),
+                        description=item.get("description"),
+                        tools=item.get("tools", []),
+                    )
+                    for item in parsed_payload.get("agents", [])
+                ],
+                tools=[
+                    Tool(
+                        name=item.get("name", "unknown"),
+                        version=item.get("version"),
+                        source=item.get("source"),
+                        scope=item.get("scope"),
+                    )
+                    for item in parsed_payload.get("tools", [])
+                ],
+                mcp_servers=[
+                    MCPServer(
+                        name=item.get("name", "unknown"),
+                        endpoint=item.get("endpoint", ""),
+                        capabilities=item.get("capabilities", []),
+                        auth_mode=item.get("auth_mode"),
+                    )
+                    for item in parsed_payload.get("mcp_servers", [])
+                ],
+                dependencies=[
+                    Dependency(
+                        name=item.get("name", "unknown"),
+                        version=item.get("version"),
+                        license=item.get("license"),
+                        vulnerabilities=item.get("vulnerabilities", []),
+                    )
+                    for item in parsed_payload.get("dependencies", [])
+                ],
+                metadata=parsed_payload.get("metadata", {}),
+            )
+        return cls(
+            project_name=payload.get("project_name", "unknown"),
+            mode=payload.get("mode", "scan"),
+            generated_at=payload.get("generated_at", _now_utc_iso()),
+            findings=findings,
+            parsed_project=parsed_project,
+            summary=payload.get("summary", {}),
+            trace_ids=payload.get("trace_ids", []),
+            scenario_results=scenario_results,
+            metadata=payload.get("metadata", {}),
+        )
+
+    @staticmethod
+    def severity_totals(findings: Iterable[RadarFinding]) -> Dict[str, int]:
+        totals: Dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+        for finding in findings:
+            severity = normalize_severity(finding.severity)
+            totals.setdefault(severity, 0)
+            totals[severity] += 1
+        totals["total"] = sum(v for k, v in totals.items() if k != "total")
+        return totals

--- a/agentic_radar/object_store.py
+++ b/agentic_radar/object_store.py
@@ -1,0 +1,49 @@
+"""Simple object store abstraction for evidence artifacts."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class ObjectStoreError(Exception):
+    """Raised when storing artifacts fails."""
+
+
+class ObjectStore:
+    """Minimal interface for storing files."""
+
+    def put_file(self, source: Path, *, destination_name: Optional[str] = None) -> Path:
+        raise NotImplementedError
+
+    def put_json(self, payload: Dict[str, Any], *, destination_name: Optional[str] = None) -> Path:
+        raise NotImplementedError
+
+
+class LocalObjectStore(ObjectStore):
+    """Filesystem-backed object store implementation."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def put_file(self, source: Path, *, destination_name: Optional[str] = None) -> Path:
+        source = Path(source)
+        if not source.exists():
+            raise ObjectStoreError(f"Source file '{source}' does not exist")
+        destination_name = destination_name or source.name
+        destination = self.root / destination_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        return destination
+
+    def put_json(self, payload: Dict[str, Any], *, destination_name: Optional[str] = None) -> Path:
+        destination_name = destination_name or f"{uuid.uuid4().hex}.json"
+        destination = self.root / destination_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("w", encoding="utf-8") as file:
+            json.dump(payload, file, indent=2)
+        return destination

--- a/agentic_radar/parser.py
+++ b/agentic_radar/parser.py
@@ -1,0 +1,131 @@
+"""Project parser for Agentic Radar."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .models import AgentComponent, Dependency, MCPServer, ParsedProject, Tool
+
+
+class ParserError(Exception):
+    """Raised when parsing fails."""
+
+
+class ProjectParser:
+    """Parse agentic projects into structured metadata."""
+
+    manifest_candidates: Iterable[str] = (
+        "agentic_radar.json",
+        "agentic_radar_manifest.json",
+        "radar_manifest.json",
+    )
+
+    def __init__(self, manifest_path: Optional[Path] = None) -> None:
+        self._explicit_manifest = manifest_path
+
+    def parse(self, root: Path) -> ParsedProject:
+        root = Path(root)
+        if not root.exists() or not root.is_dir():
+            raise ParserError(f"Project root '{root}' does not exist or is not a directory")
+
+        manifest_path = self._explicit_manifest or self._discover_manifest(root)
+        if manifest_path is not None:
+            data = self._load_manifest(manifest_path)
+        else:
+            data = self._derive_manifest(root)
+
+        project_name = data.get("project") or data.get("project_name") or root.name
+
+        agents = [
+            AgentComponent(
+                name=item.get("name", "unknown"),
+                description=item.get("description"),
+                tools=list(item.get("tools", [])),
+            )
+            for item in data.get("agents", [])
+        ]
+
+        tools = [
+            Tool(
+                name=item.get("name", "unknown"),
+                version=item.get("version"),
+                source=item.get("source"),
+                scope=item.get("scope"),
+            )
+            for item in data.get("tools", [])
+        ]
+
+        mcp_servers = [
+            MCPServer(
+                name=item.get("name", "unknown"),
+                endpoint=item.get("endpoint", ""),
+                capabilities=list(item.get("capabilities", [])),
+                auth_mode=item.get("auth_mode"),
+            )
+            for item in data.get("mcp_servers", [])
+        ]
+
+        dependencies = [
+            Dependency(
+                name=item.get("name", "unknown"),
+                version=item.get("version"),
+                license=item.get("license"),
+                vulnerabilities=list(item.get("vulnerabilities", [])),
+            )
+            for item in data.get("dependencies", [])
+        ]
+
+        metadata: Dict[str, object] = dict(data.get("metadata", {}))
+        if manifest_path is not None:
+            metadata.setdefault("manifest_path", str(manifest_path))
+            metadata.setdefault("manifest_discovered", True)
+        else:
+            metadata.setdefault("manifest_generated", True)
+
+        return ParsedProject(
+            root=root,
+            project_name=project_name,
+            agents=agents,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            dependencies=dependencies,
+            metadata=metadata,
+        )
+
+    def _discover_manifest(self, root: Path) -> Optional[Path]:
+        for candidate in self.manifest_candidates:
+            manifest_path = root / candidate
+            if manifest_path.exists():
+                return manifest_path
+        return None
+
+    def _load_manifest(self, manifest_path: Path) -> Dict[str, object]:
+        try:
+            with Path(manifest_path).open("r", encoding="utf-8") as file:
+                return json.load(file)
+        except json.JSONDecodeError as exc:
+            raise ParserError(f"Failed to parse manifest '{manifest_path}': {exc}") from exc
+
+    def _derive_manifest(self, root: Path) -> Dict[str, object]:
+        agents: List[Dict[str, object]] = []
+        seen_agents = set()
+        for file in root.rglob("*.py"):
+            if file.name.startswith("test_"):
+                continue
+            agent_name = file.stem.replace("_", "-")
+            if agent_name in seen_agents:
+                continue
+            seen_agents.add(agent_name)
+            agents.append({"name": agent_name, "tools": []})
+
+        metadata = {"derived_from_source": True}
+        return {
+            "project": root.name,
+            "agents": agents,
+            "tools": [],
+            "mcp_servers": [],
+            "dependencies": [],
+            "metadata": metadata,
+        }

--- a/agentic_radar/reporting.py
+++ b/agentic_radar/reporting.py
@@ -1,0 +1,70 @@
+"""Report builder for Agentic Radar."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from .models import ParsedProject, RadarFinding, RadarReport, ScenarioResult
+
+
+class ReportBuilder:
+    """Construct structured radar reports."""
+
+    def __init__(self, include_project_snapshot: bool = True) -> None:
+        self.include_project_snapshot = include_project_snapshot
+
+    def build(
+        self,
+        project: ParsedProject,
+        findings: Iterable[RadarFinding],
+        *,
+        mode: str,
+        trace_ids: Optional[Iterable[str]] = None,
+        scenario_results: Optional[Iterable[ScenarioResult]] = None,
+        metadata: Optional[dict] = None,
+    ) -> RadarReport:
+        findings_list = list(findings)
+        trace_id_list = list(trace_ids or [])
+        scenario_list = list(scenario_results or [])
+        summary = {
+            "findings": RadarReport.severity_totals(findings_list),
+            "inventory": {
+                "agents": len(project.agents),
+                "tools": len(project.tools),
+                "mcp_servers": len(project.mcp_servers),
+                "dependencies": len(project.dependencies),
+            },
+            "mode": mode,
+        }
+        report = RadarReport(
+            project_name=project.project_name,
+            mode=mode,
+            findings=findings_list,
+            parsed_project=project if self.include_project_snapshot else None,
+            summary=summary,
+            trace_ids=trace_id_list,
+            scenario_results=scenario_list,
+            metadata=dict(metadata or {}),
+        )
+        return report
+
+
+def build_report(
+    project: ParsedProject,
+    findings: Iterable[RadarFinding],
+    *,
+    mode: str,
+    trace_ids: Optional[Iterable[str]] = None,
+    scenario_results: Optional[Iterable[ScenarioResult]] = None,
+    metadata: Optional[dict] = None,
+    include_project_snapshot: bool = True,
+) -> RadarReport:
+    builder = ReportBuilder(include_project_snapshot=include_project_snapshot)
+    return builder.build(
+        project,
+        findings,
+        mode=mode,
+        trace_ids=trace_ids,
+        scenario_results=scenario_results,
+        metadata=metadata,
+    )

--- a/agentic_radar/runner.py
+++ b/agentic_radar/runner.py
@@ -1,0 +1,139 @@
+"""Execution helpers for the Agentic Radar CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+from .detectors import MCPDetector, ToolInventoryDetector, VulnerabilityDetector, run_detectors
+from .models import ParsedProject, RadarReport, ScenarioResult
+from .object_store import LocalObjectStore
+from .parser import ProjectParser
+from .reporting import build_report
+from .testing import TestRunner
+
+
+@dataclass
+class ScanConfig:
+    """Configuration for a radar scan run."""
+
+    root: Path
+    output_path: Path
+    object_store_path: Optional[Path] = None
+    trace_ids: List[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+    detectors: Optional[Sequence] = None
+    parser: Optional[ProjectParser] = None
+    include_project_snapshot: bool = True
+
+
+@dataclass
+class ScanResult:
+    """Result of executing a radar scan."""
+
+    report: RadarReport
+    output_path: Path
+    stored_artifact: Optional[Path]
+
+
+@dataclass
+class TestConfig(ScanConfig):
+    """Configuration for a radar test run."""
+
+    __test__ = False
+    scenarios: List[str] = field(default_factory=list)
+
+
+@dataclass
+class TestResult:
+    """Result of executing radar tests."""
+
+    __test__ = False
+    report: RadarReport
+    output_path: Path
+    stored_artifact: Optional[Path]
+    scenario_results: List[ScenarioResult]
+
+
+def _default_detectors() -> List:
+    return [ToolInventoryDetector(), MCPDetector(), VulnerabilityDetector()]
+
+
+def _resolve_detectors(detectors: Optional[Sequence]) -> List:
+    if detectors is None:
+        return _default_detectors()
+    return list(detectors)
+
+
+def _parse_project(config: ScanConfig) -> ParsedProject:
+    parser = config.parser or ProjectParser()
+    return parser.parse(config.root)
+
+
+def _write_and_store(report: RadarReport, config: ScanConfig) -> Optional[Path]:
+    output_path = Path(config.output_path)
+    report.write_json(output_path)
+    stored_artifact: Optional[Path] = None
+    if config.object_store_path:
+        store = LocalObjectStore(config.object_store_path)
+        stored_artifact = store.put_file(output_path, destination_name=output_path.name)
+    return stored_artifact
+
+
+def run_scan(config: ScanConfig) -> ScanResult:
+    project = _parse_project(config)
+    detectors = _resolve_detectors(config.detectors)
+    findings = run_detectors(project, detectors)
+    metadata = dict(config.metadata)
+    metadata.setdefault("mode", "scan")
+    metadata.setdefault("detectors", [getattr(detector, "name", "detector") for detector in detectors])
+    metadata.setdefault("trace_id_count", len(config.trace_ids))
+
+    report = build_report(
+        project,
+        findings,
+        mode="scan",
+        trace_ids=config.trace_ids,
+        metadata=metadata,
+        include_project_snapshot=config.include_project_snapshot,
+    )
+
+    stored_artifact = _write_and_store(report, config)
+    return ScanResult(report=report, output_path=Path(config.output_path), stored_artifact=stored_artifact)
+
+
+def run_test(config: TestConfig) -> TestResult:
+    project = _parse_project(config)
+    detectors = _resolve_detectors(config.detectors)
+    findings = run_detectors(project, detectors)
+
+    test_runner = TestRunner()
+    scenario_names = list(config.scenarios) if config.scenarios else list(test_runner.scenarios)
+    scenario_findings, scenario_results = test_runner.run(project, override_scenarios=scenario_names)
+    all_findings = findings + scenario_findings
+
+    metadata = dict(config.metadata)
+    metadata.setdefault("mode", "test")
+    metadata.setdefault("detectors", [getattr(detector, "name", "detector") for detector in detectors] + ["scenario-runner"])
+    metadata.setdefault("trace_id_count", len(config.trace_ids))
+    metadata["scenarios"] = scenario_names
+    metadata["scenario_failures"] = [result.name for result in scenario_results if result.status == "failed"]
+
+    report = build_report(
+        project,
+        all_findings,
+        mode="test",
+        trace_ids=config.trace_ids,
+        scenario_results=scenario_results,
+        metadata=metadata,
+        include_project_snapshot=config.include_project_snapshot,
+    )
+
+    stored_artifact = _write_and_store(report, config)
+    return TestResult(
+        report=report,
+        output_path=Path(config.output_path),
+        stored_artifact=stored_artifact,
+        scenario_results=scenario_results,
+    )

--- a/agentic_radar/testing.py
+++ b/agentic_radar/testing.py
@@ -1,0 +1,72 @@
+"""Scenario-based testing utilities for Agentic Radar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from .models import ParsedProject, RadarFinding, ScenarioResult
+
+
+DEFAULT_SCENARIOS = [
+    "prompt-injection",
+    "pii-leakage",
+    "harmful-content",
+    "tool-abuse",
+]
+
+
+class TestRunner:
+    """Run adversarial scenarios and map failures to findings."""
+
+    def __init__(self, scenarios: Optional[Sequence[str]] = None) -> None:
+        self.scenarios = list(scenarios) if scenarios else list(DEFAULT_SCENARIOS)
+
+    def run(
+        self,
+        project: ParsedProject,
+        override_scenarios: Optional[Sequence[str]] = None,
+    ) -> Tuple[List[RadarFinding], List[ScenarioResult]]:
+        scenario_names = list(override_scenarios) if override_scenarios else self.scenarios
+        expectations = project.metadata.get("test_expectations", {})
+        notes = project.metadata.get("test_notes", {})
+
+        findings: List[RadarFinding] = []
+        results: List[ScenarioResult] = []
+
+        for scenario in scenario_names:
+            expectation = str(expectations.get(scenario, "pass")).lower()
+            detail = notes.get(scenario)
+            if expectation in {"fail", "failed"}:
+                results.append(ScenarioResult(name=scenario, status="failed", details=detail))
+                findings.append(
+                    RadarFinding(
+                        identifier=f"SCENARIO-FAIL::{scenario}",
+                        title=f"Scenario '{scenario}' failed security tests",
+                        severity="high",
+                        description=f"Scenario '{scenario}' produced an unsafe response during radar tests.",
+                        owasp_llm=["LLM01"],
+                        owasp_agentic=["Agentic-Adversarial"],
+                        subject=scenario,
+                        remediation="Review guardrails and mitigations for this scenario.",
+                        detector="scenario-runner",
+                    )
+                )
+            elif expectation in {"warn", "warning"}:
+                results.append(ScenarioResult(name=scenario, status="warning", details=detail))
+                findings.append(
+                    RadarFinding(
+                        identifier=f"SCENARIO-WARN::{scenario}",
+                        title=f"Scenario '{scenario}' produced warning signals",
+                        severity="medium",
+                        description=f"Scenario '{scenario}' triggered warning-level mitigations.",
+                        owasp_llm=["LLM03"],
+                        owasp_agentic=["Agentic-Adversarial"],
+                        subject=scenario,
+                        remediation="Investigate mitigations and tighten guard thresholds.",
+                        detector="scenario-runner",
+                    )
+                )
+            else:
+                results.append(ScenarioResult(name=scenario, status="passed", details=detail))
+        return findings, results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentic-radar"
+version = "0.1.0"
+description = "Agentic radar CLI for scanning agentic systems and packaging evidence."
+readme = "README.md"
+authors = [{name = "OP Observe", email = "dev@opobserve.local"}]
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+
+[project.scripts]
+agentic-radar = "agentic_radar.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,87 @@
+"""CLI integration tests for Agentic Radar."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from agentic_radar.cli import main
+
+
+def _write_manifest(project_dir: Path) -> None:
+    manifest = {
+        "project": "sample-app",
+        "agents": [{"name": "controller", "tools": ["search"]}],
+        "tools": [
+            {"name": "search", "version": None, "source": "https://example.com/tool"},
+        ],
+        "mcp_servers": [],
+        "dependencies": [],
+        "metadata": {},
+    }
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "agentic_radar.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def test_cli_scan_and_evidence_pack(tmp_path, capsys):
+    project_dir = tmp_path / "project"
+    _write_manifest(project_dir)
+
+    report_path = tmp_path / "cli-report.json"
+    store_path = tmp_path / "store"
+    exit_code = main(
+        [
+            "scan",
+            str(project_dir),
+            "--output",
+            str(report_path),
+            "--object-store",
+            str(store_path),
+            "--trace-id",
+            "trace-xyz",
+            "--label",
+            "env=dev",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Report written to" in captured.out
+    assert report_path.exists()
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["project_name"] == "sample-app"
+    assert payload["trace_ids"] == ["trace-xyz"]
+    assert payload["metadata"]["detectors"]
+    assert list(store_path.glob("*.json"))
+
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "radar.log").write_text("radar log entry", encoding="utf-8")
+
+    pack_path = tmp_path / "evidence.zip"
+    evidence_store = tmp_path / "evidence-store"
+    exit_code = main(
+        [
+            "evidence",
+            "pack",
+            "--findings",
+            str(report_path),
+            "--logs",
+            str(logs_dir),
+            "--trace-id",
+            "trace-xyz",
+            "--object-store",
+            str(evidence_store),
+            "--output",
+            str(pack_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Evidence pack created" in captured.out
+    assert pack_path.exists()
+    with zipfile.ZipFile(pack_path, "r") as archive:
+        metadata = json.loads(archive.read("metadata.json").decode("utf-8"))
+    assert metadata["findings"]
+    assert metadata["trace_ids"] == ["trace-xyz"]
+    assert list(evidence_store.glob("*.zip"))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,102 @@
+"""Tests for radar scan and test runners."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agentic_radar.runner import ScanConfig, TestConfig, run_scan, run_test
+
+
+def _write_manifest(project_dir: Path, *, include_test_expectations: bool = False) -> None:
+    manifest = {
+        "project": "sample-app",
+        "agents": [
+            {"name": "orchestrator", "tools": ["search", "email"]},
+        ],
+        "tools": [
+            {"name": "search", "version": None, "source": "https://example.com/search"},
+            {"name": "email", "version": "1.2.3", "source": "internal"},
+        ],
+        "mcp_servers": [
+            {"name": "inventory", "endpoint": "https://inventory.example", "capabilities": [], "auth_mode": "anonymous"}
+        ],
+        "dependencies": [
+            {
+                "name": "requests",
+                "version": "2.0.0",
+                "vulnerabilities": [
+                    {
+                        "id": "CVE-2024-9999",
+                        "severity": "high",
+                        "description": "SSL verification bypass",
+                        "fix_version": "2.31.0",
+                    }
+                ],
+            }
+        ],
+        "metadata": {"environment": "staging"},
+    }
+    if include_test_expectations:
+        manifest["metadata"].update(
+            {
+                "test_expectations": {
+                    "prompt-injection": "fail",
+                    "pii-leakage": "pass",
+                },
+                "test_notes": {"prompt-injection": "Guardrail rejected prompt"},
+            }
+        )
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "agentic_radar.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def test_run_scan_produces_findings_and_stores(tmp_path):
+    project_dir = tmp_path / "project"
+    _write_manifest(project_dir)
+    output_path = tmp_path / "report.json"
+    store_path = tmp_path / "store"
+
+    config = ScanConfig(
+        root=project_dir,
+        output_path=output_path,
+        object_store_path=store_path,
+        trace_ids=["trace-1"],
+        metadata={"release": "2025.09"},
+    )
+    result = run_scan(config)
+
+    assert output_path.exists()
+    with output_path.open("r", encoding="utf-8") as file:
+        payload = json.load(file)
+    assert payload["summary"]["findings"]["total"] >= 3
+    assert payload["metadata"]["detectors"]
+    assert payload["trace_ids"] == ["trace-1"]
+
+    assert result.stored_artifact is not None
+    assert result.stored_artifact.exists()
+    assert list(store_path.glob("*.json"))
+
+
+def test_run_test_records_scenarios(tmp_path):
+    project_dir = tmp_path / "project"
+    _write_manifest(project_dir, include_test_expectations=True)
+    output_path = tmp_path / "test-report.json"
+
+    config = TestConfig(
+        root=project_dir,
+        output_path=output_path,
+        trace_ids=["trace-2"],
+        scenarios=["prompt-injection", "pii-leakage"],
+    )
+    result = run_test(config)
+
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    scenario_status = {item["name"]: item["status"] for item in payload["scenario_results"]}
+    assert scenario_status["prompt-injection"] == "failed"
+    assert scenario_status["pii-leakage"] == "passed"
+    assert "prompt-injection" in payload["metadata"]["scenario_failures"]
+    assert payload["summary"]["findings"]["high"] >= 1
+    assert result.report.mode == "test"
+    assert any(finding["id"].startswith("SCENARIO-FAIL") for finding in payload["findings"])


### PR DESCRIPTION
## Summary
- add an `agentic_radar` package that parses projects, runs detectors, builds reports, and exposes CLI `scan`/`test` commands
- wire evidence packaging with local object store support and expose it via the CLI `evidence pack` command
- cover the new flows with pytest integration tests for runners and CLI usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b7367114832bab28a1ef260060b7