### PR TITLE
Establish repository baseline configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,49 @@
+# Baseline ignore rules for OP-Observe.
+# This file is part of the repository-wide merge-conflict prevention baseline.
+# Do not modify it in feature branches; update via the baseline process only.
+
+# Virtual environments
+env/
+
+# Python cache and compiled files
 __pycache__/
 *.pyc
+*.pyo
+*.pyd
+
+# Build and packaging artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+*.egg
+pip-wheel-metadata/
+*.so
+*.dylib
+
+# Vendored dependencies
+vendor/
+
+# Logs and runtime diagnostics
+*.log
+
+# Coverage and test outputs
+.coverage
+coverage.xml
+htmlcov/
+.pytest_cache/
+.tox/
+.nox/
+.mypy_cache/
+.pyre/
+.ruff_cache/
+
+# Editor and IDE settings
+*.swp
+*.swo
+.idea/
+.vscode/
+.DS_Store
+
+# Local data artifacts
+*.sqlite3

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,5 +1,50 @@
-"""OP-Observe core package placeholder."""
+"""Baseline namespace exports for the :mod:`op_observe` package.
+
+This module exists to provide a consistent import surface across branches so
+that feature work does not fight over the package initializer. Do **not**
+modify this file in feature branches; propose changes through the baseline
+update process instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Iterable
 
 __all__ = [
-    "agentic_security",
+    "observability",
+    "security",
+    "retrieval",
+    "telemetry",
+    "enablement",
+    "core",
 ]
+
+
+def _iter_public_names() -> Iterable[str]:
+    """Return the public attribute names for :func:`__dir__`."""
+
+    return set(globals()) | set(__all__)
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Lazily import reserved submodules when they are first accessed."""
+
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    try:
+        return importlib.import_module(f".{name}", __name__)
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
+        if exc.name == f"{__name__}.{name}":
+            raise AttributeError(
+                f"Baseline namespace {name!r} is reserved but not yet implemented."
+            ) from exc
+        raise
+
+
+def __dir__() -> list[str]:
+    """Expose the baseline namespace for better auto-completion support."""
+
+    return sorted(_iter_public_names())

--- a/tests/_baseline_imports.py
+++ b/tests/_baseline_imports.py
@@ -1,0 +1,15 @@
+"""Baseline helper to ensure the repository root is importable during tests.
+
+This module is part of the merge-conflict prevention baseline. Execute it via
+``run_path`` from test modules to guarantee that :mod:`op_observe` can be
+resolved without customising individual conftest files.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,24 @@
-import sys
-from pathlib import Path
+"""Baseline pytest configuration shared across all modules.
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+This file is part of the repository-wide merge-conflict prevention baseline.
+Feature branches must not modify it; request changes through the baseline
+update process instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def baseline_packages() -> tuple[str, ...]:
+    """Return the canonical top-level packages exported by :mod:`op_observe`."""
+
+    return (
+        "observability",
+        "security",
+        "retrieval",
+        "telemetry",
+        "enablement",
+        "core",
+    )

--- a/tests/test_baseline_package.py
+++ b/tests/test_baseline_package.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+from runpy import run_path
+
+run_path(Path(__file__).resolve().with_name("_baseline_imports.py"))
+
+import op_observe
+
+
+def test_op_observe_exports_match_baseline(baseline_packages: tuple[str, ...]) -> None:
+    """Ensure the package exposes the canonical baseline namespace."""
+
+    assert isinstance(op_observe.__all__, list)
+    assert op_observe.__all__ == list(baseline_packages)
+
+
+def test_op_observe_dir_contains_baseline_exports(
+    baseline_packages: tuple[str, ...]
+) -> None:
+    """``dir(op_observe)`` should surface the reserved namespace entries."""
+
+    module_dir = set(dir(op_observe))
+    for name in baseline_packages:
+        assert name in module_dir
+
+
+def test_gitignore_contains_baseline_patterns() -> None:
+    """Verify the unified ignore rules are present and well documented."""
+
+    gitignore_path = Path(__file__).resolve().parents[1] / ".gitignore"
+    lines = gitignore_path.read_text().splitlines()
+    patterns = [
+        line.strip()
+        for line in lines
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+    required_patterns = [
+        "env/",
+        "__pycache__/",
+        "*.pyc",
+        "*.pyo",
+        "*.pyd",
+        "build/",
+        "dist/",
+        "*.egg-info/",
+        ".eggs/",
+        "pip-wheel-metadata/",
+        "vendor/",
+        "*.log",
+        ".coverage",
+        "coverage.xml",
+        "htmlcov/",
+        ".pytest_cache/",
+        ".tox/",
+        ".nox/",
+        ".mypy_cache/",
+        ".pyre/",
+        ".ruff_cache/",
+    ]
+
+    for pattern in required_patterns:
+        assert pattern in patterns, f"{pattern} missing from baseline .gitignore"
+
+    assert len(patterns) == len(
+        set(patterns)
+    ), "Duplicate ignore patterns detected in baseline .gitignore"
+
+    comment_lines = [line for line in lines if line.strip().startswith("#")]
+    assert any(
+        "baseline" in line.lower() for line in comment_lines
+    ), "Expected baseline documentation comments in .gitignore"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,8 @@
 from datetime import date
+from pathlib import Path
+from runpy import run_path
+
+run_path(Path(__file__).resolve().with_name("_baseline_imports.py"))
 
 from op_observe.agentic_security.loader import (
     get_agentic_ai_mapping,

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+from runpy import run_path
+
+run_path(Path(__file__).resolve().with_name("_baseline_imports.py"))
+
 from op_observe.agentic_security import (
     generate_mitigation_checklist,
     map_finding_to_tables,


### PR DESCRIPTION
## Summary
- consolidate the root .gitignore into a documented baseline that covers envs, build artifacts, caches, and logs
- rewrite op_observe/__init__.py and tests/conftest.py to provide documented baseline exports and fixtures with lazy imports
- add a reusable baseline import helper and tests that validate package exports and ignore rules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca0fbf75c4832bafb74c0ddd1fdd51