### PR TITLE
Add security detectors and OWASP vulnerability mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/agentic_radar/__init__.py
+++ b/agentic_radar/__init__.py
@@ -1,0 +1,21 @@
+"""Agentic Radar security detectors and mappers."""
+
+from .detectors.mcp import MCPServerDetector, MCPServerFinding
+from .detectors.tools import ToolDetector, ToolFinding
+from .detectors.vulnerabilities import (
+    MappingRule,
+    OWASPMapper,
+    VulnerabilityFinding,
+    VulnerabilityMapper,
+)
+
+__all__ = [
+    "MCPServerDetector",
+    "MCPServerFinding",
+    "ToolDetector",
+    "ToolFinding",
+    "MappingRule",
+    "OWASPMapper",
+    "VulnerabilityFinding",
+    "VulnerabilityMapper",
+]

--- a/agentic_radar/detectors/__init__.py
+++ b/agentic_radar/detectors/__init__.py
@@ -1,0 +1,16 @@
+"""Detectors for the Agentic Radar security plane."""
+
+from .mcp import MCPServerDetector, MCPServerFinding
+from .tools import ToolDetector, ToolFinding
+from .vulnerabilities import MappingRule, OWASPMapper, VulnerabilityFinding, VulnerabilityMapper
+
+__all__ = [
+    "MCPServerDetector",
+    "MCPServerFinding",
+    "ToolDetector",
+    "ToolFinding",
+    "MappingRule",
+    "OWASPMapper",
+    "VulnerabilityFinding",
+    "VulnerabilityMapper",
+]

--- a/agentic_radar/detectors/base.py
+++ b/agentic_radar/detectors/base.py
@@ -1,0 +1,60 @@
+"""Common utilities for Agentic Radar detectors."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Optional, Sequence, Set
+
+
+@dataclass
+class Finding:
+    """Base finding returned by detectors."""
+
+    detector: str
+    name: str
+    location: Optional[str]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def format_location(path: Path, lineno: Optional[int]) -> str:
+    """Return a human-friendly location string."""
+
+    if lineno:
+        return f"{path}:{lineno}"
+    return str(path)
+
+
+class SourceWalker:
+    """Utility mixin that walks files and directories."""
+
+    def __init__(self, *, extensions: Optional[Sequence[str]] = None) -> None:
+        self._extensions: Optional[Set[str]] = set(extensions) if extensions else None
+
+    def iter_files(self, paths: Iterable[Path | str]) -> Iterator[Path]:
+        """Yield source files under *paths* respecting configured extensions."""
+
+        for raw_path in paths:
+            path = Path(raw_path)
+            if path.is_dir():
+                yield from self._iter_directory(path)
+            elif path.is_file():
+                if self._should_include(path):
+                    yield path
+
+    def _iter_directory(self, directory: Path) -> Iterator[Path]:
+        for path in directory.rglob("*"):
+            if path.is_file() and self._should_include(path):
+                yield path
+
+    def _should_include(self, path: Path) -> bool:
+        if not self._extensions:
+            return True
+        return path.suffix in self._extensions
+
+
+def normalise_string(value: Optional[str]) -> Optional[str]:
+    """Normalise a string for comparison by lowercasing and stripping."""
+
+    if value is None:
+        return None
+    return value.strip().lower()

--- a/agentic_radar/detectors/mcp.py
+++ b/agentic_radar/detectors/mcp.py
@@ -1,0 +1,214 @@
+"""Detection of Model Context Protocol (MCP) servers."""
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .base import Finding, SourceWalker, format_location
+
+
+_ENDPOINT_KEYS = {"uri", "url", "endpoint", "server", "server_url", "base_url", "address"}
+_CAPABILITY_KEYS = {"capabilities", "tools", "permissions"}
+
+
+@dataclass
+class MCPServerFinding(Finding):
+    """Finding capturing metadata about an MCP server or client."""
+
+    endpoint: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class MCPServerDetector(SourceWalker):
+    """Detector for discovering MCP servers in source code and configuration."""
+
+    def __init__(self) -> None:
+        super().__init__(extensions=(".py", ".json", ".yaml", ".yml"))
+
+    def scan_paths(self, paths: Iterable[Path | str]) -> List[MCPServerFinding]:
+        findings: List[MCPServerFinding] = []
+        for path in self.iter_files(paths):
+            findings.extend(self._scan_file(path))
+        return findings
+
+    def _scan_file(self, path: Path) -> List[MCPServerFinding]:
+        suffix = path.suffix.lower()
+        if suffix == ".py":
+            return self._scan_python(path)
+        if suffix in {".json", ".yaml", ".yml"}:
+            return self._scan_config(path)
+        return []
+
+    def _scan_python(self, path: Path) -> List[MCPServerFinding]:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            return []
+        visitor = _McpAstVisitor(path)
+        visitor.visit(tree)
+        return visitor.findings
+
+    def _scan_config(self, path: Path) -> List[MCPServerFinding]:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+
+        suffix = path.suffix.lower()
+        data: Any
+        if suffix == ".json":
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                data = None
+        else:
+            data = _safe_load_yaml(text)
+
+        findings: List[MCPServerFinding] = []
+        if data is not None:
+            for entry in _find_mcp_in_mapping(data):
+                findings.append(
+                    MCPServerFinding(
+                        detector="mcp",
+                        name=entry.get("name") or entry.get("id") or "mcp_server",
+                        endpoint=entry.get("endpoint"),
+                        location=str(path),
+                        metadata={k: v for k, v in entry.items() if k not in {"name", "endpoint"}},
+                    )
+                )
+        else:
+            findings.extend(_scan_text_for_mcp(text, path))
+        return findings
+
+
+class _McpAstVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.findings: List[MCPServerFinding] = []
+
+    def visit_Call(self, node: ast.Call) -> Any:  # type: ignore[override]
+        call_name = _name_from_node(node.func)
+        if call_name and _looks_like_mcp(call_name):
+            endpoint = _extract_endpoint(node)
+            capabilities = _extract_capabilities(node)
+            finding = MCPServerFinding(
+                detector="mcp",
+                name=call_name.split(".")[-1],
+                endpoint=endpoint,
+                location=format_location(self._path, getattr(node, "lineno", None)),
+                metadata={
+                    "call": call_name,
+                    "capabilities": capabilities,
+                },
+            )
+            self.findings.append(finding)
+        self.generic_visit(node)
+
+
+def _name_from_node(node: Optional[ast.AST]) -> Optional[str]:
+    if node is None:
+        return None
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _name_from_node(node.value)
+        if parent:
+            return f"{parent}.{node.attr}"
+        return node.attr
+    if hasattr(ast, "unparse"):
+        try:
+            return ast.unparse(node)  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - fallback
+            return None
+    return None
+
+
+def _extract_endpoint(node: ast.Call) -> Optional[str]:
+    for keyword in node.keywords:
+        if keyword.arg and keyword.arg.lower() in _ENDPOINT_KEYS:
+            value = keyword.value
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                return value.value
+    if node.args:
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return first.value
+    return None
+
+
+def _extract_capabilities(node: ast.Call) -> List[str]:
+    for keyword in node.keywords:
+        if keyword.arg and keyword.arg.lower() in _CAPABILITY_KEYS:
+            value = keyword.value
+            if isinstance(value, (ast.List, ast.Tuple)):
+                items = []
+                for elt in value.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        items.append(elt.value)
+                return items
+    return []
+
+
+def _looks_like_mcp(call_name: str) -> bool:
+    lower = call_name.lower()
+    return "mcp" in lower or "modelcontext" in lower or "model_context" in lower
+
+
+def _safe_load_yaml(text: str) -> Any:
+    try:
+        import yaml  # type: ignore
+
+        return yaml.safe_load(text)
+    except Exception:
+        return None
+
+
+def _find_mcp_in_mapping(node: Any, *, trail: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+    trail = trail or []
+    findings: List[Dict[str, Any]] = []
+
+    if isinstance(node, dict):
+        is_mcp = any("mcp" in str(key).lower() for key in node.keys())
+        endpoint_key = next((key for key in node.keys() if str(key).lower() in _ENDPOINT_KEYS), None)
+        endpoint = node.get(endpoint_key) if endpoint_key else None
+        if is_mcp or endpoint:
+            entry: Dict[str, Any] = {
+                "name": node.get("name") or node.get("id") or ".".join(trail) if trail else "mcp",
+                "endpoint": endpoint if isinstance(endpoint, str) else None,
+            }
+            for key in node.keys():
+                value = node[key]
+                if str(key).lower() in _CAPABILITY_KEYS and isinstance(value, list):
+                    entry[str(key)] = value
+            findings.append(entry)
+        for key, value in node.items():
+            findings.extend(_find_mcp_in_mapping(value, trail=trail + [str(key)]))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            findings.extend(_find_mcp_in_mapping(value, trail=trail + [str(index)]))
+    return findings
+
+
+def _scan_text_for_mcp(text: str, path: Path) -> List[MCPServerFinding]:
+    findings: List[MCPServerFinding] = []
+    pattern = re.compile(r"(?P<endpoint>(?:mcp|https?)://[^\s'\"]+)")
+    for match in pattern.finditer(text):
+        endpoint = match.group("endpoint")
+        findings.append(
+            MCPServerFinding(
+                detector="mcp",
+                name="mcp_endpoint",
+                endpoint=endpoint,
+                location=f"{path}:?",
+                metadata={"extracted_from": "text"},
+            )
+        )
+    return findings

--- a/agentic_radar/detectors/tools.py
+++ b/agentic_radar/detectors/tools.py
@@ -1,0 +1,194 @@
+"""Detection of tools defined in agentic applications."""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .base import Finding, SourceWalker, format_location
+
+
+_TOOL_DECORATOR_KEYWORDS = ("tool", "register_tool", "langchain.tool", "lc_tool")
+_TOOL_CLASS_SUFFIXES = ("Tool", "BaseTool")
+_TOOL_CALL_KEYWORDS = ("Tool", "StructuredTool", "PythonREPLTool", "BaseTool")
+
+
+@dataclass
+class ToolFinding(Finding):
+    """Finding representing a tool definition."""
+
+    definition_type: str = "tool"
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+class ToolDetector(SourceWalker):
+    """Detector that discovers tool definitions in Python source files."""
+
+    def __init__(self) -> None:
+        super().__init__(extensions=(".py",))
+
+    def scan_paths(self, paths: Iterable[Path | str]) -> List[ToolFinding]:
+        findings: List[ToolFinding] = []
+        for path in self.iter_files(paths):
+            findings.extend(self._scan_file(path))
+        return findings
+
+    def _scan_file(self, path: Path) -> List[ToolFinding]:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            return []
+
+        visitor = _ToolAstVisitor(path)
+        visitor.visit(tree)
+        return visitor.findings
+
+
+class _ToolAstVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.findings: List[ToolFinding] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # pragma: no cover - alias handled below
+        self._maybe_add_function(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._maybe_add_function(node)
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        bases = [_name_from_node(base) for base in node.bases]
+        matches = [base for base in bases if _is_tool_class(base)]
+        if matches:
+            metadata = {
+                "bases": bases,
+            }
+            finding = ToolFinding(
+                detector="tool",
+                name=node.name,
+                location=format_location(self._path, getattr(node, "lineno", None)),
+                definition_type="class",
+                metadata=metadata,
+            )
+            self.findings.append(finding)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self._maybe_add_assignment(node)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        self._maybe_add_assignment(node)
+        self.generic_visit(node)
+
+    def _maybe_add_function(self, node: ast.AST) -> None:
+        decorator_names = [_name_from_node(dec) for dec in getattr(node, "decorator_list", [])]
+        matches = [name for name in decorator_names if _is_tool_decorator(name)]
+        if matches:
+            metadata = {
+                "decorators": decorator_names,
+                "docstring": ast.get_docstring(node),
+            }
+            finding = ToolFinding(
+                detector="tool",
+                name=getattr(node, "name", "<anonymous>"),
+                location=format_location(self._path, getattr(node, "lineno", None)),
+                definition_type="function",
+                metadata=metadata,
+            )
+            self.findings.append(finding)
+
+    def _maybe_add_assignment(self, node: ast.Assign | ast.AnnAssign) -> None:
+        value = getattr(node, "value", None)
+        if not isinstance(value, ast.Call):
+            return
+
+        call_name = _name_from_node(value.func)
+        if not _is_tool_call(call_name):
+            return
+
+        targets: List[str] = []
+        raw_targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in raw_targets:
+            if isinstance(target, ast.Name):
+                targets.append(target.id)
+            else:
+                try:
+                    targets.append(ast.unparse(target))  # type: ignore[attr-defined]
+                except Exception:  # pragma: no cover - best effort for Python <3.9
+                    continue
+
+        metadata = {
+            "call": call_name,
+            "keywords": {kw.arg: _literal_from_node(kw.value) for kw in value.keywords if kw.arg},
+        }
+        finding = ToolFinding(
+            detector="tool",
+            name=", ".join(targets) if targets else call_name or "<unknown>",
+            location=format_location(self._path, getattr(node, "lineno", None)),
+            definition_type="assignment",
+            metadata=metadata,
+        )
+        self.findings.append(finding)
+
+
+def _name_from_node(node: Optional[ast.AST]) -> Optional[str]:
+    if node is None:
+        return None
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _name_from_node(node.value)
+        if parent:
+            return f"{parent}.{node.attr}"
+        return node.attr
+    if isinstance(node, ast.Call):  # pragma: no cover - defensive path
+        return _name_from_node(node.func)
+    if hasattr(ast, "unparse"):
+        try:
+            return ast.unparse(node)  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - best effort
+            return None
+    return None
+
+
+def _literal_from_node(node: ast.AST) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_literal_from_node(elt) for elt in node.elts]
+    if isinstance(node, ast.Dict):
+        return {
+            _literal_from_node(key): _literal_from_node(value)
+            for key, value in zip(node.keys, node.values)
+        }
+    return _name_from_node(node)
+
+
+def _is_tool_decorator(name: Optional[str]) -> bool:
+    if not name:
+        return False
+    lower = name.lower()
+    return any(lower.endswith(keyword) or keyword in lower for keyword in _TOOL_DECORATOR_KEYWORDS)
+
+
+def _is_tool_class(name: Optional[str]) -> bool:
+    if not name:
+        return False
+    return any(name.endswith(suffix) for suffix in _TOOL_CLASS_SUFFIXES)
+
+
+def _is_tool_call(name: Optional[str]) -> bool:
+    if not name:
+        return False
+    base = name.split(".")[-1]
+    if base in _TOOL_CALL_KEYWORDS:
+        return True
+    return base.lower().endswith("tool")

--- a/agentic_radar/detectors/vulnerabilities.py
+++ b/agentic_radar/detectors/vulnerabilities.py
@@ -1,0 +1,388 @@
+"""Map dependency vulnerabilities to OWASP categories."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .base import Finding, normalise_string
+
+
+LLM_CATEGORY_TITLES: Dict[str, str] = {
+    "LLM01": "Prompt Injection",
+    "LLM02": "Insecure Output Handling",
+    "LLM03": "Training Data Poisoning",
+    "LLM04": "Model Denial of Service",
+    "LLM05": "Supply Chain Vulnerabilities",
+    "LLM06": "Sensitive Information Disclosure",
+    "LLM07": "Insecure Plugin Design",
+    "LLM08": "Excessive Agency",
+    "LLM09": "Overreliance",
+    "LLM10": "Model Theft",
+}
+
+AGENTIC_CATEGORY_TITLES: Dict[str, str] = {
+    "AA01": "Prompt & Input Integrity",
+    "AA02": "Tool Misuse & Escalation",
+    "AA03": "External Service Abuse",
+    "AA04": "Sensitive Data Exposure",
+    "AA05": "Model or Data Exfiltration",
+    "AA06": "Supply Chain & Dependency Risk",
+    "AA07": "Secrets & Credential Handling",
+    "AA08": "Observability & Audit Gaps",
+    "AA09": "Safety & Policy Violations",
+    "AA10": "Resilience & Availability",
+}
+
+SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "moderate": 2, "low": 1}
+
+
+@dataclass
+class VulnerabilityFinding(Finding):
+    """Unified representation of dependency vulnerabilities."""
+
+    package: str = ""
+    version: str = ""
+    ecosystem: Optional[str] = None
+    vulnerability_id: str = ""
+    severity: Optional[str] = None
+    summary: Optional[str] = None
+    aliases: Tuple[str, ...] = tuple()
+    fix_versions: Tuple[str, ...] = tuple()
+    references: Tuple[str, ...] = tuple()
+    source: Optional[str] = None
+    owasp_llm_categories: Tuple[str, ...] = tuple()
+    owasp_agentic_categories: Tuple[str, ...] = tuple()
+
+
+@dataclass
+class MappingRule:
+    """Rule that maps vulnerability attributes to OWASP categories."""
+
+    llm_codes: Tuple[str, ...]
+    agentic_codes: Tuple[str, ...]
+    keywords: Tuple[str, ...] = tuple()
+    package: Optional[str] = None
+    ecosystem: Optional[str] = None
+    id_prefixes: Tuple[str, ...] = tuple()
+    severity_at_least: Optional[str] = None
+
+    def matches(self, finding: VulnerabilityFinding) -> bool:
+        if self.package and normalise_string(finding.package) != normalise_string(self.package):
+            return False
+        if self.ecosystem and normalise_string(finding.ecosystem) != normalise_string(self.ecosystem):
+            return False
+        if self.id_prefixes:
+            identifier = (finding.vulnerability_id or "").upper()
+            aliases = {alias.upper() for alias in finding.aliases}
+            if not any(identifier.startswith(prefix.upper()) or any(alias.startswith(prefix.upper()) for alias in aliases) for prefix in self.id_prefixes):
+                return False
+        if self.keywords:
+            haystacks = " ".join(filter(None, [finding.summary, " ".join(finding.aliases)])).lower()
+            if not any(keyword.lower() in haystacks for keyword in self.keywords):
+                return False
+        if self.severity_at_least:
+            required = SEVERITY_ORDER.get(self.severity_at_least.lower(), 0)
+            actual = SEVERITY_ORDER.get((finding.severity or "").lower(), 0)
+            if actual < required:
+                return False
+        return True
+
+
+def _format_category(code: str, titles: Dict[str, str]) -> str:
+    title = titles.get(code, "Unknown")
+    return f"{code} - {title}"
+
+
+DEFAULT_RULES: Tuple[MappingRule, ...] = (
+    MappingRule(
+        llm_codes=("LLM01",),
+        agentic_codes=("AA01",),
+        keywords=("prompt injection", "prompt-injection"),
+    ),
+    MappingRule(
+        llm_codes=("LLM07",),
+        agentic_codes=("AA02",),
+        keywords=("remote code execution", "command injection", "arbitrary command"),
+    ),
+    MappingRule(
+        llm_codes=("LLM06",),
+        agentic_codes=("AA04",),
+        keywords=("information disclosure", "sensitive data", "secret exposure"),
+    ),
+    MappingRule(
+        llm_codes=("LLM04",),
+        agentic_codes=("AA10",),
+        keywords=("denial of service", "dos", "resource exhaustion"),
+    ),
+    MappingRule(
+        llm_codes=("LLM07",),
+        agentic_codes=("AA03",),
+        keywords=("ssrf", "server-side request forgery", "unvalidated request"),
+    ),
+    MappingRule(
+        llm_codes=("LLM05",),
+        agentic_codes=("AA06",),
+        keywords=("supply chain", "dependency", "package takeover"),
+    ),
+    MappingRule(
+        llm_codes=("LLM07",),
+        agentic_codes=("AA07",),
+        keywords=("credential", "secret", "token leak"),
+    ),
+)
+
+
+class OWASPMapper:
+    """Apply OWASP mapping rules to vulnerability findings."""
+
+    def __init__(
+        self,
+        *,
+        rules: Sequence[MappingRule] = DEFAULT_RULES,
+        default_llm_codes: Sequence[str] = ("LLM05",),
+        default_agentic_codes: Sequence[str] = ("AA06",),
+    ) -> None:
+        self._rules = tuple(rules)
+        self._default_llm_codes = tuple(default_llm_codes)
+        self._default_agentic_codes = tuple(default_agentic_codes)
+
+    def apply(self, finding: VulnerabilityFinding) -> VulnerabilityFinding:
+        llm_codes = set()
+        agentic_codes = set()
+        for rule in self._rules:
+            if rule.matches(finding):
+                llm_codes.update(rule.llm_codes)
+                agentic_codes.update(rule.agentic_codes)
+        if not llm_codes:
+            llm_codes.update(self._default_llm_codes)
+        if not agentic_codes:
+            agentic_codes.update(self._default_agentic_codes)
+        finding.owasp_llm_categories = tuple(
+            _format_category(code, LLM_CATEGORY_TITLES) for code in sorted(llm_codes)
+        )
+        finding.owasp_agentic_categories = tuple(
+            _format_category(code, AGENTIC_CATEGORY_TITLES) for code in sorted(agentic_codes)
+        )
+        return finding
+
+
+class VulnerabilityMapper:
+    """Unify OSV and pip-audit results and map to OWASP categories."""
+
+    def __init__(self, *, owasp_mapper: Optional[OWASPMapper] = None) -> None:
+        self._owasp_mapper = owasp_mapper or OWASPMapper()
+
+    # ------------------------------------------------------------------
+    # OSV parsing
+    # ------------------------------------------------------------------
+    def from_osv(self, payload: Dict[str, Any]) -> List[VulnerabilityFinding]:
+        findings: List[VulnerabilityFinding] = []
+        for result in payload.get("results", []):
+            source_path = _extract_source_path(result.get("source"))
+            for package in result.get("packages", []):
+                pkg_meta = package.get("package", {}) or {}
+                package_name = pkg_meta.get("name") or "unknown"
+                ecosystem = pkg_meta.get("ecosystem")
+                versions = package.get("versions") or ["unknown"]
+                vulnerabilities = package.get("vulnerabilities") or []
+                for vuln in vulnerabilities:
+                    severity = _extract_osv_severity(vuln)
+                    summary = vuln.get("summary") or vuln.get("details")
+                    aliases = tuple(vuln.get("aliases") or ())
+                    references = tuple(
+                        ref.get("url") for ref in vuln.get("references", []) if isinstance(ref, dict) and ref.get("url")
+                    )
+                    fix_versions = _extract_osv_fix_versions(vuln)
+                    vuln_id = vuln.get("id") or aliases[0] if aliases else package_name
+                    for version in versions:
+                        finding = VulnerabilityFinding(
+                            detector="vulnerability",
+                            name=vuln_id,
+                            location=source_path,
+                            package=package_name,
+                            version=version,
+                            ecosystem=ecosystem,
+                            vulnerability_id=vuln_id,
+                            severity=severity,
+                            summary=summary,
+                            aliases=aliases,
+                            fix_versions=fix_versions,
+                            references=references,
+                            source="osv",
+                            metadata={
+                                "source": "osv",
+                                "path": source_path,
+                            },
+                        )
+                        findings.append(self._owasp_mapper.apply(finding))
+        return findings
+
+    # ------------------------------------------------------------------
+    # pip-audit parsing
+    # ------------------------------------------------------------------
+    def from_pip_audit(self, payload: Dict[str, Any]) -> List[VulnerabilityFinding]:
+        findings: List[VulnerabilityFinding] = []
+        for dependency in payload.get("dependencies", []):
+            package_name = dependency.get("name") or "unknown"
+            version = dependency.get("version") or "unknown"
+            for vuln in dependency.get("vulns", []):
+                vuln_id = vuln.get("id") or package_name
+                aliases = tuple(vuln.get("aliases") or ())
+                severity = _normalise_severity(vuln.get("severity"))
+                summary = vuln.get("description") or vuln.get("summary")
+                fix_versions = tuple(vuln.get("fix_versions") or ())
+                references = tuple(vuln.get("references") or ())
+                finding = VulnerabilityFinding(
+                    detector="vulnerability",
+                    name=vuln_id,
+                    location="pip-audit",
+                    package=package_name,
+                    version=version,
+                    ecosystem="PyPI",
+                    vulnerability_id=vuln_id,
+                    severity=severity,
+                    summary=summary,
+                    aliases=aliases,
+                    fix_versions=fix_versions,
+                    references=references,
+                    source="pip-audit",
+                    metadata={"source": "pip-audit"},
+                )
+                findings.append(self._owasp_mapper.apply(finding))
+        return findings
+
+    # ------------------------------------------------------------------
+    # Deduplication & merging
+    # ------------------------------------------------------------------
+    def merge(self, *finding_groups: Iterable[VulnerabilityFinding]) -> List[VulnerabilityFinding]:
+        merged: Dict[Tuple[str, str], VulnerabilityFinding] = {}
+        for group in finding_groups:
+            for finding in group:
+                key = (finding.package.lower(), finding.vulnerability_id.upper())
+                if key not in merged:
+                    merged[key] = finding
+                    continue
+                existing = merged[key]
+                merged[key] = _merge_findings(existing, finding, self._owasp_mapper)
+        return list(merged.values())
+
+
+def _extract_source_path(source: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not isinstance(source, dict):
+        return None
+    for key in ("path", "file", "name"):
+        value = source.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _extract_osv_severity(vuln: Dict[str, Any]) -> Optional[str]:
+    severities = []
+    for entry in vuln.get("severity", []) or []:
+        score = entry.get("score")
+        if not isinstance(score, str):
+            continue
+        numeric_score = _score_to_float(score)
+        if numeric_score is not None:
+            severities.append(numeric_score)
+    if severities:
+        return _severity_from_score(max(severities))
+    database_specific = vuln.get("database_specific") or {}
+    severity = database_specific.get("severity")
+    if isinstance(severity, str):
+        return severity.upper()
+    return None
+
+
+def _extract_osv_fix_versions(vuln: Dict[str, Any]) -> Tuple[str, ...]:
+    versions = set()
+    for key in ("fix_versions", "fixed_versions"):
+        for version in vuln.get(key) or []:
+            if isinstance(version, str):
+                versions.add(version)
+    database_specific = vuln.get("database_specific") or {}
+    for key in ("fix_versions", "fixed_versions"):
+        for version in database_specific.get(key) or []:
+            if isinstance(version, str):
+                versions.add(version)
+    for affected in vuln.get("affected", []) or []:
+        ranges = affected.get("ranges") or []
+        for range_entry in ranges:
+            for event in range_entry.get("events", []):
+                fixed = event.get("fixed")
+                if isinstance(fixed, str):
+                    versions.add(fixed)
+    return tuple(sorted(versions))
+
+
+def _score_to_float(score: str) -> Optional[float]:
+    try:
+        if "/" in score:
+            score = score.split("/", 1)[0]
+        return float(score)
+    except (TypeError, ValueError):
+        return None
+
+
+def _severity_from_score(score: float) -> str:
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score > 0:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _normalise_severity(severity: Optional[str]) -> Optional[str]:
+    if severity is None:
+        return None
+    return severity.upper()
+
+
+def _merge_findings(
+    left: VulnerabilityFinding,
+    right: VulnerabilityFinding,
+    mapper: OWASPMapper,
+) -> VulnerabilityFinding:
+    aliases = tuple(sorted(set(left.aliases) | set(right.aliases)))
+    fix_versions = tuple(sorted(set(left.fix_versions) | set(right.fix_versions)))
+    references = tuple(sorted(set(left.references) | set(right.references)))
+    severity = _pick_more_severe(left.severity, right.severity)
+    summary = left.summary or right.summary
+    metadata = {**left.metadata, **right.metadata}
+    merged = VulnerabilityFinding(
+        detector="vulnerability",
+        name=left.name,
+        location=left.location or right.location,
+        package=left.package,
+        version=left.version or right.version,
+        ecosystem=left.ecosystem or right.ecosystem,
+        vulnerability_id=left.vulnerability_id,
+        severity=severity,
+        summary=summary,
+        aliases=aliases,
+        fix_versions=fix_versions,
+        references=references,
+        source=left.source or right.source,
+        metadata=metadata,
+    )
+    return mapper.apply(merged)
+
+
+def _pick_more_severe(left: Optional[str], right: Optional[str]) -> Optional[str]:
+    candidates = [(left or "").lower(), (right or "").lower()]
+    best_level = 0
+    best_value: Optional[str] = None
+    fallback: Optional[str] = None
+    for candidate in candidates:
+        level = SEVERITY_ORDER.get(candidate, 0)
+        if candidate and fallback is None:
+            fallback = candidate.upper()
+        if level > best_level and candidate:
+            best_level = level
+            best_value = candidate.upper()
+    return best_value or fallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "op-observe"
+version = "0.1.0"
+description = "Agentic security detectors for OP-Observe"
+requires-python = ">=3.10"
+
+[tool.pytest.ini_options]
+python_files = ["test_*.py"]
+addopts = "-q"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path for package imports.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_mcp_detector.py
+++ b/tests/test_mcp_detector.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+from agentic_radar.detectors.mcp import MCPServerDetector
+
+
+def test_mcp_detector_parses_python_and_config(tmp_path) -> None:
+    python_source = """
+from mcp import MCPClient
+import mcp
+
+client = MCPClient("mcp://inventory", capabilities=["search", "store"])
+
+
+async def connect() -> None:
+    return await mcp.Client.connect(uri="https://mcp.internal/api", capabilities=["query"])
+"""
+    py_path = tmp_path / "app.py"
+    py_path.write_text(python_source, encoding="utf-8")
+
+    config = {
+        "agents": [
+            {
+                "name": "rag-agent",
+                "mcp": {
+                    "endpoint": "https://mcp.example/api",
+                    "capabilities": ["ingest"],
+                },
+            }
+        ]
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    detector = MCPServerDetector()
+    findings = detector.scan_paths([tmp_path])
+
+    endpoints = {finding.endpoint for finding in findings if finding.endpoint}
+    assert "mcp://inventory" in endpoints
+    assert "https://mcp.internal/api" in endpoints
+    assert "https://mcp.example/api" in endpoints
+
+    client_call = next(f for f in findings if f.metadata.get("call") == "MCPClient")
+    assert set(client_call.metadata.get("capabilities", [])) == {"search", "store"}
+
+    config_finding = next(f for f in findings if f.endpoint == "https://mcp.example/api")
+    assert config_finding.metadata.get("capabilities") == ["ingest"]

--- a/tests/test_tool_detector.py
+++ b/tests/test_tool_detector.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import textwrap
+
+from agentic_radar.detectors.tools import ToolDetector
+
+
+def test_tool_detector_identifies_multiple_tool_patterns(tmp_path) -> None:
+    source = textwrap.dedent(
+        """
+        from langchain.tools import tool, Tool, BaseTool
+
+        @tool
+        def search(query: str) -> str:
+            '''Search through a document index.'''
+            return "ok"
+
+        class MathHelper(BaseTool):
+            description = "Perform arithmetic"
+
+        custom = Tool(name="custom", func=lambda: None)
+
+
+        def unrelated(value: int) -> int:
+            return value
+        """
+    )
+    path = tmp_path / "sample_tools.py"
+    path.write_text(source, encoding="utf-8")
+
+    findings = ToolDetector().scan_paths([path])
+    finding_lookup = {finding.name: finding for finding in findings}
+
+    assert {finding.definition_type for finding in findings} == {"function", "class", "assignment"}
+    assert finding_lookup["search"].metadata["docstring"] == "Search through a document index."
+    assert "BaseTool" in finding_lookup["MathHelper"].metadata["bases"]
+    assert finding_lookup["custom"].metadata["call"].endswith("Tool")
+    assert "unrelated" not in finding_lookup

--- a/tests/test_vulnerability_mapper.py
+++ b/tests/test_vulnerability_mapper.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from agentic_radar.detectors.vulnerabilities import VulnerabilityMapper
+
+
+def build_osv_payload() -> dict:
+    return {
+        "results": [
+            {
+                "source": {"path": "requirements.txt"},
+                "packages": [
+                    {
+                        "package": {"name": "promptlib", "ecosystem": "PyPI"},
+                        "versions": ["1.2.3"],
+                        "vulnerabilities": [
+                            {
+                                "id": "CVE-2024-1234",
+                                "summary": "Prompt injection allows remote tool takeover.",
+                                "aliases": ["GHSA-aaaa-bbbb"],
+                                "severity": [
+                                    {"type": "CVSS_V3", "score": "9.1"}
+                                ],
+                                "references": [
+                                    {"type": "ADVISORY", "url": "https://example.com/CVE-2024-1234"}
+                                ],
+                                "database_specific": {"fixed_versions": ["1.2.4"]},
+                                "affected": [
+                                    {
+                                        "ranges": [
+                                            {"events": [{"fixed": "1.2.4"}]}
+                                        ]
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def build_pip_audit_payload() -> dict:
+    return {
+        "dependencies": [
+            {
+                "name": "promptlib",
+                "version": "1.2.3",
+                "vulns": [
+                    {
+                        "id": "CVE-2024-1234",
+                        "aliases": ["GHSA-aaaa-bbbb"],
+                        "severity": "high",
+                        "description": "Remote code execution via command injection in plugin.",
+                        "fix_versions": ["1.2.5"],
+                        "references": ["https://example.com/CVE-2024-1234"],
+                    }
+                ],
+            },
+            {
+                "name": "agentshell",
+                "version": "0.4.0",
+                "vulns": [
+                    {
+                        "id": "GHSA-2024-0001",
+                        "severity": "medium",
+                        "description": "Generic dependency risk without specific keywords.",
+                    }
+                ],
+            },
+        ]
+    }
+
+
+def test_vulnerability_mapper_combines_osv_and_pip_audit() -> None:
+    mapper = VulnerabilityMapper()
+
+    osv_findings = mapper.from_osv(build_osv_payload())
+    assert len(osv_findings) == 1
+    osv = osv_findings[0]
+    assert osv.package == "promptlib"
+    assert osv.severity == "CRITICAL"
+    assert "LLM01 - Prompt Injection" in osv.owasp_llm_categories
+    assert "AA01 - Prompt & Input Integrity" in osv.owasp_agentic_categories
+    assert set(osv.fix_versions) == {"1.2.4"}
+
+    pip_findings = mapper.from_pip_audit(build_pip_audit_payload())
+    assert len(pip_findings) == 2
+
+    command_exec = next(f for f in pip_findings if f.vulnerability_id == "CVE-2024-1234")
+    assert "LLM07 - Insecure Plugin Design" in command_exec.owasp_llm_categories
+    assert "AA02 - Tool Misuse & Escalation" in command_exec.owasp_agentic_categories
+
+    generic = next(f for f in pip_findings if f.vulnerability_id == "GHSA-2024-0001")
+    assert generic.owasp_llm_categories == ("LLM05 - Supply Chain Vulnerabilities",)
+    assert generic.owasp_agentic_categories == ("AA06 - Supply Chain & Dependency Risk",)
+
+    merged = mapper.merge(osv_findings, pip_findings)
+    assert len(merged) == 2
+
+    merged_prompt = next(f for f in merged if f.vulnerability_id == "CVE-2024-1234")
+    assert set(merged_prompt.fix_versions) == {"1.2.4", "1.2.5"}
+    assert merged_prompt.severity == "CRITICAL"


### PR DESCRIPTION
## Summary
- add reusable detector primitives plus scanners for LangChain tools and MCP servers
- implement an OWASP-aware vulnerability mapper that normalises OSV and pip-audit results
- cover the new behaviour with pytest-based unit tests and a project configuration stub

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b7289cb4832bb2bb425b7c2f4c0f