### PR TITLE
Add OpenLLMetry-inspired instrumentation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/op_observe/__init__.py
+++ b/op_observe/__init__.py
@@ -1,0 +1,41 @@
+"""Open Observability instrumentation helpers.
+
+This package provides lightweight OpenTelemetry-inspired primitives
+as well as decorators that mimic the behaviour of OpenLLMetry and
+OpenInference integrations for LangChain and LangGraph based agent
+applications. The goal is to expose an ergonomic API that can be used
+without external dependencies while still emitting rich span metadata
+for testing purposes.
+"""
+
+from .instrumentation.decorators import (
+    instrument_agent_function,
+    instrument_langchain_tool,
+    instrument_langgraph_node,
+)
+from .telemetry import (
+    InMemoryOTLPCollector,
+    InMemoryOTLPSpanExporter,
+    SimpleSpanProcessor,
+    StatusCode,
+    Tracer,
+    TracerProvider,
+    get_tracer,
+    reset_tracer_provider,
+    set_tracer_provider,
+)
+
+__all__ = [
+    "instrument_agent_function",
+    "instrument_langchain_tool",
+    "instrument_langgraph_node",
+    "InMemoryOTLPCollector",
+    "InMemoryOTLPSpanExporter",
+    "SimpleSpanProcessor",
+    "StatusCode",
+    "Tracer",
+    "TracerProvider",
+    "get_tracer",
+    "reset_tracer_provider",
+    "set_tracer_provider",
+]

--- a/op_observe/instrumentation/decorators.py
+++ b/op_observe/instrumentation/decorators.py
@@ -1,0 +1,232 @@
+"""Instrumentation decorators that mimic OpenLLMetry/OpenInference."""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, Dict, Optional
+
+from ..telemetry import StatusCode, get_tracer
+
+# Attribute keys following the OpenLLMetry/OpenInference conventions.
+OPENINFERENCE_FRAMEWORK_ATTR = "openinference.framework"
+OPENINFERENCE_SPAN_KIND_ATTR = "openinference.span.kind"
+OPENINFERENCE_TOOL_NAME_ATTR = "openinference.tool.name"
+OPENINFERENCE_NODE_NAME_ATTR = "openinference.graph.node.name"
+OPENINFERENCE_NODE_TYPE_ATTR = "openinference.graph.node.type"
+OPENINFERENCE_INPUTS_ATTR = "openinference.inputs"
+OPENINFERENCE_OUTPUTS_ATTR = "openinference.outputs"
+OPENLLMETRY_FRAMEWORK_ATTR = "openllmetry.framework"
+OPENLLMETRY_ENTITY_ATTR = "openllmetry.entity.type"
+OPENLLMETRY_MODEL_ATTR = "openllmetry.llm.model"
+OPENLLMETRY_OPERATION_ATTR = "openllmetry.llm.operation"
+OPENLLMETRY_INSTRUMENTATION_ATTR = "openllmetry.instrumentation"
+OPENLLMETRY_VERSION_ATTR = "openllmetry.instrumentation.version"
+ERROR_FLAG_ATTR = "error"
+ERROR_TYPE_ATTR = "error.type"
+ERROR_MESSAGE_ATTR = "error.message"
+
+DEFAULT_INSTRUMENTATION_VERSION = "0.1-test"
+DEFAULT_INSTRUMENTATION_NAME = "op-observe"
+
+
+CallableT = Callable[..., Any]
+DecoratorT = Callable[[CallableT], CallableT]
+
+
+def instrument_agent_function(
+    framework: str,
+    span_kind: str,
+    entity_name: Optional[str] = None,
+    *,
+    llm_model: Optional[str] = None,
+    llm_operation: str = "agent_call",
+    span_name: Optional[str] = None,
+    tracer_name: Optional[str] = None,
+    capture_inputs: bool = True,
+    capture_outputs: bool = True,
+    extra_attributes: Optional[Dict[str, Any]] = None,
+) -> DecoratorT:
+    """Generic decorator used by the concrete LangChain/LangGraph helpers."""
+
+    if tracer_name is None:
+        tracer_name = f"{DEFAULT_INSTRUMENTATION_NAME}.{framework}"
+
+    static_attributes = {
+        OPENINFERENCE_FRAMEWORK_ATTR: framework,
+        OPENINFERENCE_SPAN_KIND_ATTR: span_kind,
+        OPENLLMETRY_FRAMEWORK_ATTR: framework,
+        OPENLLMETRY_ENTITY_ATTR: span_kind,
+        OPENLLMETRY_OPERATION_ATTR: llm_operation,
+        OPENLLMETRY_INSTRUMENTATION_ATTR: DEFAULT_INSTRUMENTATION_NAME,
+        OPENLLMETRY_VERSION_ATTR: DEFAULT_INSTRUMENTATION_VERSION,
+    }
+
+    if llm_model is not None:
+        static_attributes[OPENLLMETRY_MODEL_ATTR] = llm_model
+
+    if extra_attributes:
+        static_attributes.update(extra_attributes)
+
+    def decorator(func: CallableT) -> CallableT:
+        nonlocal entity_name
+        resolved_entity_name = entity_name or func.__name__
+        span_prefix = _framework_display_name(framework)
+        default_span_name = span_name or f"{span_prefix}.{resolved_entity_name}"
+
+        attributes = dict(static_attributes)
+
+        def update_entity_attributes(mapping: Dict[str, Any]) -> None:
+            if span_kind == "tool":
+                mapping[OPENINFERENCE_TOOL_NAME_ATTR] = resolved_entity_name
+            else:
+                mapping[OPENINFERENCE_NODE_NAME_ATTR] = resolved_entity_name
+
+        update_entity_attributes(attributes)
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer(tracer_name)
+            call_attributes = _merge_dynamic_attributes(
+                attributes,
+                args,
+                kwargs,
+                capture_inputs=capture_inputs,
+            )
+            with tracer.start_as_current_span(default_span_name, attributes=call_attributes) as span:
+                try:
+                    result = await func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover - handled in tests
+                    _annotate_exception(span, exc)
+                    raise
+                else:
+                    if capture_outputs:
+                        span.set_attribute(OPENINFERENCE_OUTPUTS_ATTR, _safe_repr(result))
+                    span.set_status(StatusCode.OK)
+                    return result
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_tracer(tracer_name)
+            call_attributes = _merge_dynamic_attributes(
+                attributes,
+                args,
+                kwargs,
+                capture_inputs=capture_inputs,
+            )
+            with tracer.start_as_current_span(default_span_name, attributes=call_attributes) as span:
+                try:
+                    result = func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover - handled in tests
+                    _annotate_exception(span, exc)
+                    raise
+                else:
+                    if capture_outputs:
+                        span.set_attribute(OPENINFERENCE_OUTPUTS_ATTR, _safe_repr(result))
+                    span.set_status(StatusCode.OK)
+                    return result
+
+        return async_wrapper if inspect.iscoroutinefunction(func) else sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def instrument_langchain_tool(
+    tool_name: Optional[str] = None,
+    *,
+    llm_model: Optional[str] = None,
+    span_name: Optional[str] = None,
+    tracer_name: Optional[str] = None,
+    llm_operation: str = "tool_call",
+    capture_inputs: bool = True,
+    capture_outputs: bool = True,
+    extra_attributes: Optional[Dict[str, Any]] = None,
+) -> DecoratorT:
+    """Instrument a LangChain tool or tool-like callable."""
+
+    attributes = dict(extra_attributes or {})
+    attributes[OPENINFERENCE_SPAN_KIND_ATTR] = "tool"
+
+    return instrument_agent_function(
+        framework="langchain",
+        span_kind="tool",
+        entity_name=tool_name,
+        llm_model=llm_model,
+        llm_operation=llm_operation,
+        span_name=span_name,
+        tracer_name=tracer_name,
+        capture_inputs=capture_inputs,
+        capture_outputs=capture_outputs,
+        extra_attributes=attributes,
+    )
+
+
+def instrument_langgraph_node(
+    node_name: Optional[str] = None,
+    *,
+    node_type: Optional[str] = None,
+    llm_model: Optional[str] = None,
+    span_name: Optional[str] = None,
+    tracer_name: Optional[str] = None,
+    llm_operation: str = "node_execution",
+    capture_inputs: bool = True,
+    capture_outputs: bool = True,
+    extra_attributes: Optional[Dict[str, Any]] = None,
+) -> DecoratorT:
+    """Instrument a LangGraph node or callable."""
+
+    attributes = extra_attributes.copy() if extra_attributes else {}
+    if node_type is not None:
+        attributes[OPENINFERENCE_NODE_TYPE_ATTR] = node_type
+
+    return instrument_agent_function(
+        framework="langgraph",
+        span_kind="node",
+        entity_name=node_name,
+        llm_model=llm_model,
+        llm_operation=llm_operation,
+        span_name=span_name,
+        tracer_name=tracer_name,
+        capture_inputs=capture_inputs,
+        capture_outputs=capture_outputs,
+        extra_attributes=attributes,
+    )
+
+
+
+def _framework_display_name(framework: str) -> str:
+    mapping = {
+        "langchain": "LangChain",
+        "langgraph": "LangGraph",
+    }
+    return mapping.get(framework, framework.title())
+
+
+
+def _merge_dynamic_attributes(
+    base_attributes: Dict[str, Any],
+    args: Any,
+    kwargs: Any,
+    *,
+    capture_inputs: bool,
+) -> Dict[str, Any]:
+    call_attributes = dict(base_attributes)
+    if capture_inputs:
+        call_attributes[OPENINFERENCE_INPUTS_ATTR] = {
+            "args": _safe_repr(args),
+            "kwargs": _safe_repr(kwargs),
+        }
+    return call_attributes
+
+
+def _annotate_exception(span, exc: Exception) -> None:
+    span.set_attribute(ERROR_FLAG_ATTR, True)
+    span.set_attribute(ERROR_TYPE_ATTR, exc.__class__.__name__)
+    span.set_attribute(ERROR_MESSAGE_ATTR, str(exc))
+
+
+def _safe_repr(value: Any) -> str:
+    try:
+        return repr(value)
+    except Exception:  # pragma: no cover - defensive
+        return f"<unreprable {type(value).__name__}>"

--- a/op_observe/telemetry.py
+++ b/op_observe/telemetry.py
@@ -1,0 +1,282 @@
+"""Lightweight OpenTelemetry-compatible primitives used for testing.
+
+The real project would depend on ``opentelemetry`` as well as
+OpenLLMetry/OpenInference integrations. Since those libraries are not
+available in the execution environment we provide a very small shim that
+exposes the subset of behaviour required by the unit tests. The API is
+inspired by ``opentelemetry.trace`` and only implements the minimal
+surface necessary for the decorators provided in
+:mod:`op_observe.instrumentation`.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import threading
+import time
+from contextlib import AbstractContextManager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional
+
+__all__ = [
+    "SpanContext",
+    "SpanRecord",
+    "StatusCode",
+    "Span",
+    "Tracer",
+    "TracerProvider",
+    "SimpleSpanProcessor",
+    "InMemoryOTLPSpanExporter",
+    "InMemoryOTLPCollector",
+    "get_tracer",
+    "set_tracer_provider",
+    "reset_tracer_provider",
+]
+
+
+class StatusCode(str, Enum):
+    """Enumeration that mirrors the OpenTelemetry ``StatusCode`` type."""
+
+    UNSET = "UNSET"
+    OK = "OK"
+    ERROR = "ERROR"
+
+
+@dataclass(frozen=True)
+class SpanContext:
+    """Simple immutable span context holding trace and span identifiers."""
+
+    trace_id: str
+    span_id: str
+
+
+@dataclass
+class SpanRecord:
+    """Record exported by the in-memory collector."""
+
+    name: str
+    context: SpanContext
+    parent_id: Optional[str]
+    attributes: Dict[str, Any]
+    start_time: float
+    end_time: Optional[float]
+    status: StatusCode
+    instrumentation_scope: str
+    events: List[Dict[str, Any]] = field(default_factory=list)
+
+
+_current_span: ContextVar[Optional["Span"]] = ContextVar("current_span", default=None)
+
+
+def _generate_trace_id() -> str:
+    return os.urandom(16).hex()
+
+
+def _generate_span_id() -> str:
+    return os.urandom(8).hex()
+
+
+class Span:
+    """Minimal representation of an OpenTelemetry span."""
+
+    def __init__(
+        self,
+        tracer: "Tracer",
+        name: str,
+        attributes: Optional[Dict[str, Any]] = None,
+        parent: Optional["Span"] = None,
+    ) -> None:
+        self._tracer = tracer
+        self._name = name
+        parent_context = parent.context if parent is not None else None
+        trace_id = parent_context.trace_id if parent_context else _generate_trace_id()
+        self._context = SpanContext(trace_id=trace_id, span_id=_generate_span_id())
+        self._record = SpanRecord(
+            name=name,
+            context=self._context,
+            parent_id=parent_context.span_id if parent_context else None,
+            attributes=dict(attributes or {}),
+            start_time=time.time(),
+            end_time=None,
+            status=StatusCode.UNSET,
+            instrumentation_scope=tracer.instrumentation_scope,
+        )
+        self._ended = False
+
+    # ------------------------------------------------------------------
+    # OpenTelemetry-like surface
+    # ------------------------------------------------------------------
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def context(self) -> SpanContext:
+        return self._context
+
+    @property
+    def attributes(self) -> Dict[str, Any]:
+        return self._record.attributes
+
+    @property
+    def status(self) -> StatusCode:
+        return self._record.status
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self._record.attributes[key] = value
+
+    def record_exception(self, exc: BaseException) -> None:
+        self._record.events.append(
+            {
+                "name": "exception",
+                "attributes": {
+                    "exception.type": exc.__class__.__name__,
+                    "exception.message": str(exc),
+                },
+            }
+        )
+
+    def set_status(self, status: StatusCode) -> None:
+        self._record.status = status
+
+    def end(self) -> None:
+        if self._ended:
+            return
+        self._record.end_time = time.time()
+        self._tracer.provider._on_end(self._record)
+        self._ended = True
+
+
+class _SpanContextManager(AbstractContextManager):
+    """Context manager returned by :meth:`Tracer.start_as_current_span`."""
+
+    def __init__(self, span: Span) -> None:
+        self._span = span
+        self._token = None
+
+    def __enter__(self) -> Span:
+        self._token = _current_span.set(self._span)
+        return self._span
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if exc_type is None:
+            if self._span.status == StatusCode.UNSET:
+                self._span.set_status(StatusCode.OK)
+        else:
+            self._span.record_exception(exc)  # type: ignore[arg-type]
+            self._span.set_status(StatusCode.ERROR)
+        try:
+            self._span.end()
+        finally:
+            if self._token is not None:
+                _current_span.reset(self._token)
+        return False
+
+
+class Tracer:
+    """Very small tracer implementation."""
+
+    def __init__(self, provider: "TracerProvider", instrumentation_scope: str) -> None:
+        self.provider = provider
+        self.instrumentation_scope = instrumentation_scope
+
+    def start_span(self, name: str, attributes: Optional[Dict[str, Any]] = None) -> Span:
+        parent = _current_span.get()
+        return Span(self, name, attributes, parent)
+
+    def start_as_current_span(
+        self, name: str, attributes: Optional[Dict[str, Any]] = None
+    ) -> _SpanContextManager:
+        span = self.start_span(name, attributes)
+        return _SpanContextManager(span)
+
+
+class TracerProvider:
+    """Simplified tracer provider that keeps a list of processors."""
+
+    def __init__(self) -> None:
+        self._processors: List[SimpleSpanProcessor] = []
+
+    def get_tracer(self, instrumentation_scope: str) -> Tracer:
+        return Tracer(self, instrumentation_scope)
+
+    def add_span_processor(self, processor: "SimpleSpanProcessor") -> None:
+        self._processors.append(processor)
+
+    # Internal hook
+    def _on_end(self, record: SpanRecord) -> None:
+        for processor in self._processors:
+            processor.on_end(record)
+
+
+class SimpleSpanProcessor:
+    """Processor that immediately exports spans synchronously."""
+
+    def __init__(self, exporter: "InMemoryOTLPSpanExporter") -> None:
+        self._exporter = exporter
+
+    def on_end(self, record: SpanRecord) -> None:
+        # Export a defensive copy so later mutations do not leak.
+        self._exporter.export([copy.deepcopy(record)])
+
+
+class InMemoryOTLPSpanExporter:
+    """Small OTLP-like exporter that keeps spans in memory."""
+
+    def __init__(self) -> None:
+        self._spans: List[SpanRecord] = []
+        self._lock = threading.Lock()
+
+    def export(self, spans: Iterable[SpanRecord]) -> None:
+        with self._lock:
+            for span in spans:
+                self._spans.append(copy.deepcopy(span))
+
+    def get_finished_spans(self) -> List[SpanRecord]:
+        with self._lock:
+            return [copy.deepcopy(span) for span in self._spans]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._spans.clear()
+
+
+class InMemoryOTLPCollector:
+    """Convenience helper used by the tests to capture exported spans."""
+
+    def __init__(self) -> None:
+        self.exporter = InMemoryOTLPSpanExporter()
+        self.processor = SimpleSpanProcessor(self.exporter)
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(self.processor)
+
+    def get_finished_spans(self) -> List[SpanRecord]:
+        return self.exporter.get_finished_spans()
+
+    def clear(self) -> None:
+        self.exporter.clear()
+
+
+_global_tracer_provider = TracerProvider()
+
+
+def get_tracer(instrumentation_scope: str) -> Tracer:
+    """Return a tracer for the requested instrumentation scope."""
+
+    return _global_tracer_provider.get_tracer(instrumentation_scope)
+
+
+def set_tracer_provider(provider: TracerProvider) -> None:
+    """Replace the global tracer provider."""
+
+    global _global_tracer_provider
+    _global_tracer_provider = provider
+
+
+def reset_tracer_provider() -> None:
+    """Restore the global provider to a clean instance."""
+
+    set_tracer_provider(TracerProvider())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,79 @@
+import asyncio
+
+import pytest
+
+from op_observe import (
+    InMemoryOTLPCollector,
+    StatusCode,
+    instrument_langchain_tool,
+    instrument_langgraph_node,
+    reset_tracer_provider,
+    set_tracer_provider,
+)
+
+
+@pytest.fixture()
+def collector():
+    collector = InMemoryOTLPCollector()
+    set_tracer_provider(collector.tracer_provider)
+    yield collector
+    reset_tracer_provider()
+
+
+def test_langchain_tool_emits_span_with_attributes(collector):
+    @instrument_langchain_tool(tool_name="search", llm_model="gpt-test")
+    def search_tool(query: str, limit: int = 3) -> str:
+        return f"results for {query} (limit={limit})"
+
+    output = search_tool("observability", limit=5)
+    assert "observability" in output
+
+    spans = collector.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "LangChain.search"
+    assert span.status == StatusCode.OK
+    assert span.attributes["openinference.framework"] == "langchain"
+    assert span.attributes["openinference.span.kind"] == "tool"
+    assert span.attributes["openinference.tool.name"] == "search"
+    assert span.attributes["openllmetry.llm.model"] == "gpt-test"
+    assert "observability" in span.attributes["openinference.inputs"]["args"]
+    assert "results for" in span.attributes["openinference.outputs"]
+
+
+def test_langgraph_async_node_records_output(collector):
+    @instrument_langgraph_node(node_name="planner", node_type="decision", llm_model="gpt-async")
+    async def planner_node(goal: str) -> dict:
+        await asyncio.sleep(0)
+        return {"goal": goal, "status": "planned"}
+
+    result = asyncio.run(planner_node("ship"))
+    assert result["status"] == "planned"
+
+    spans = collector.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "LangGraph.planner"
+    assert span.attributes["openinference.graph.node.name"] == "planner"
+    assert span.attributes["openinference.graph.node.type"] == "decision"
+    assert span.attributes["openllmetry.llm.model"] == "gpt-async"
+    assert span.status == StatusCode.OK
+    assert "planned" in span.attributes["openinference.outputs"]
+
+
+def test_exception_marks_span_as_error(collector):
+    @instrument_langchain_tool(tool_name="failing")
+    def failing_tool() -> None:
+        raise ValueError("tool failure")
+
+    with pytest.raises(ValueError):
+        failing_tool()
+
+    spans = collector.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status == StatusCode.ERROR
+    assert span.attributes["error"] is True
+    assert span.attributes["error.type"] == "ValueError"
+    assert "tool failure" in span.attributes["error.message"]
+    assert span.attributes["openinference.tool.name"] == "failing"


### PR DESCRIPTION
## Summary
- implement lightweight telemetry primitives along with LangChain and LangGraph instrumentation decorators that capture OpenLLMetry/OpenInference span metadata
- provide an in-memory OTLP collector and helper utilities for testing agent tool instrumentation
- add pytest-based coverage for synchronous/asynchronous wrappers and ignore bytecode artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b6c8e418832bbe3df46a20c66296