### PR TITLE
Implement Prometheus and ClickHouse metrics export utilities

### DIFF
--- a/op_observe/telemetry/__init__.py
+++ b/op_observe/telemetry/__init__.py
@@ -1,0 +1,18 @@
+"""Telemetry utilities for OP-Observe.
+
+This module exposes convenience imports for configuring OpenTelemetry
+collectors and exporting runtime metrics to Prometheus and ClickHouse.
+"""
+
+from .collector import build_collector_config
+from .exporters import ClickHouseExporterConfig, PrometheusExporterConfig
+from .grafana import build_guardrail_dashboard
+from .metrics import MetricsRegistry
+
+__all__ = [
+    "build_collector_config",
+    "ClickHouseExporterConfig",
+    "PrometheusExporterConfig",
+    "MetricsRegistry",
+    "build_guardrail_dashboard",
+]

--- a/op_observe/telemetry/collector.py
+++ b/op_observe/telemetry/collector.py
@@ -1,0 +1,79 @@
+"""Helpers for building OpenTelemetry collector configuration."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+from .exporters import ClickHouseExporterConfig, PrometheusExporterConfig
+
+
+DEFAULT_PROCESSORS = {
+    "batch": {
+        "timeout": "5s",
+        "send_batch_size": 512,
+    },
+}
+
+
+def _merge_dict(into: MutableMapping[str, object], other: Mapping[str, object]) -> None:
+    for key, value in other.items():
+        if key not in into:
+            into[key] = value
+            continue
+        current = into[key]
+        if isinstance(current, dict) and isinstance(value, Mapping):
+            _merge_dict(current, value)
+        else:
+            into[key] = value
+
+
+def build_collector_config(
+    prometheus: PrometheusExporterConfig,
+    clickhouse: ClickHouseExporterConfig,
+    receivers: Iterable[str] | None = None,
+) -> Dict[str, object]:
+    """Return a complete OpenTelemetry collector configuration.
+
+    Parameters
+    ----------
+    prometheus:
+        Settings for the Prometheus exporter.
+    clickhouse:
+        Settings for the ClickHouse exporter.
+    receivers:
+        Optional iterable of receiver names to enable.  If omitted the
+        default OTLP gRPC/HTTP receivers are configured.
+    """
+
+    receiver_block: Dict[str, object]
+    if receivers:
+        receiver_block = {name: {} for name in receivers}
+    else:
+        receiver_block = {
+            "otlp": {
+                "protocols": {
+                    "grpc": {},
+                    "http": {},
+                }
+            }
+        }
+
+    exporters: Dict[str, object] = {}
+    _merge_dict(exporters, prometheus.otel_exporter())
+    _merge_dict(exporters, clickhouse.otel_exporter())
+
+    pipelines = {
+        "metrics": {
+            "receivers": sorted(receiver_block.keys()),
+            "processors": sorted(DEFAULT_PROCESSORS.keys()),
+            "exporters": sorted(exporters.keys()),
+        }
+    }
+
+    return {
+        "receivers": receiver_block,
+        "processors": DEFAULT_PROCESSORS,
+        "exporters": exporters,
+        "service": {
+            "pipelines": pipelines,
+        },
+    }

--- a/op_observe/telemetry/exporters.py
+++ b/op_observe/telemetry/exporters.py
@@ -1,0 +1,64 @@
+"""Exporter configuration helpers.
+
+The test-suite does not rely on real network connectivity.  Instead of
+instantiating the OpenTelemetry collector, we construct configuration
+snippets that mirror what the collector expects.  These snippets can be
+serialised to YAML by downstream tooling.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class PrometheusExporterConfig:
+    """Configuration for the OpenTelemetry Prometheus exporter."""
+
+    endpoint: str = "0.0.0.0"
+    port: int = 9464
+    metric_namespace: str = "op_observe"
+    collectors: Mapping[str, str] = field(
+        default_factory=lambda: {
+            "scrape_interval": "15s",
+            "scrape_timeout": "10s",
+        }
+    )
+
+    def otel_exporter(self) -> Dict[str, object]:
+        """Return a collector configuration fragment for Prometheus."""
+
+        return {
+            "prometheus": {
+                "endpoint": f"{self.endpoint}:{self.port}",
+                "namespace": self.metric_namespace,
+                "controller": dict(self.collectors),
+            }
+        }
+
+
+@dataclass(frozen=True)
+class ClickHouseExporterConfig:
+    """Configuration for exporting metrics to ClickHouse."""
+
+    endpoint: str = "http://localhost:8123"
+    database: str = "otel"
+    table: str = "metrics"
+    username: Optional[str] = None
+    password: Optional[str] = None
+    timeout: str = "10s"
+
+    def otel_exporter(self) -> Dict[str, object]:
+        """Return a collector configuration fragment for ClickHouse."""
+
+        exporter = {
+            "endpoint": self.endpoint,
+            "database": self.database,
+            "table": self.table,
+            "timeout": self.timeout,
+        }
+        if self.username:
+            exporter["username"] = self.username
+        if self.password:
+            exporter["password"] = self.password
+        return {"clickhouse": exporter}

--- a/op_observe/telemetry/grafana.py
+++ b/op_observe/telemetry/grafana.py
@@ -1,0 +1,51 @@
+"""Build Grafana dashboards for guardrail observability."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List
+
+
+def _panel(panel_id: int, title: str, expr: str, panel_type: str = "timeseries") -> Dict[str, object]:
+    return {
+        "id": panel_id,
+        "type": panel_type,
+        "title": title,
+        "datasource": {
+            "type": "prometheus",
+            "uid": "PROMETHEUS_DS",
+        },
+        "targets": [
+            {
+                "expr": expr,
+                "refId": "A",
+            }
+        ],
+    }
+
+
+def build_guardrail_dashboard(title: str = "Guardrail & Evals Overview") -> Dict[str, object]:
+    """Return a Grafana dashboard definition for guardrail metrics."""
+
+    panels: List[Dict[str, object]] = [
+        _panel(
+            1,
+            "Guardrail verdicts (rate)",
+            'sum(rate(guardrail_verdict_total[5m])) by (verdict)',
+        ),
+        _panel(
+            2,
+            "LLM-Critic score",
+            'avg(llm_critic_score)',
+        ),
+        _panel(
+            3,
+            "System latency p95",
+            'histogram_quantile(0.95, sum(rate(system_latency_ms_bucket[5m])) by (le))',
+        ),
+    ]
+
+    return {
+        "title": title,
+        "panels": panels,
+        "uid": f"guardrail-{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+    }

--- a/op_observe/telemetry/metrics.py
+++ b/op_observe/telemetry/metrics.py
@@ -1,0 +1,247 @@
+"""In-memory metrics registry for Prometheus and ClickHouse exports."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, List, Mapping, MutableMapping, Tuple
+
+
+LabelValues = Tuple[str, ...]
+LabelDict = Dict[str, str]
+
+
+class MetricError(ValueError):
+    """Raised when metric labels are misconfigured."""
+
+
+@dataclass
+class _MetricBase:
+    name: str
+    description: str
+    label_names: Tuple[str, ...] = ()
+
+    def _key(self, labels: Mapping[str, str]) -> LabelValues:
+        if set(labels) != set(self.label_names):
+            missing = set(self.label_names) - set(labels)
+            extra = set(labels) - set(self.label_names)
+            problems: List[str] = []
+            if missing:
+                problems.append(f"missing labels: {sorted(missing)}")
+            if extra:
+                problems.append(f"unexpected labels: {sorted(extra)}")
+            raise MetricError(
+                f"labels for metric '{self.name}' invalid ({', '.join(problems)})"
+            )
+        return tuple(labels[name] for name in self.label_names)
+
+
+@dataclass
+class CounterMetric(_MetricBase):
+    values: MutableMapping[LabelValues, float] = field(default_factory=dict)
+    label_cache: MutableMapping[LabelValues, LabelDict] = field(default_factory=dict)
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        key = self._key(labels)
+        self.values[key] = self.values.get(key, 0.0) + amount
+        if key not in self.label_cache:
+            self.label_cache[key] = dict(labels)
+
+
+@dataclass
+class GaugeMetric(_MetricBase):
+    values: MutableMapping[LabelValues, float] = field(default_factory=dict)
+    label_cache: MutableMapping[LabelValues, LabelDict] = field(default_factory=dict)
+
+    def set(self, value: float, **labels: str) -> None:
+        key = self._key(labels)
+        self.values[key] = value
+        self.label_cache[key] = dict(labels)
+
+
+@dataclass
+class HistogramMetric(_MetricBase):
+    buckets: Tuple[float, ...] = (50, 100, 200, 500, 1000)
+    samples: MutableMapping[LabelValues, List[float]] = field(default_factory=dict)
+    label_cache: MutableMapping[LabelValues, LabelDict] = field(default_factory=dict)
+
+    def observe(self, value: float, **labels: str) -> None:
+        key = self._key(labels)
+        self.samples.setdefault(key, []).append(value)
+        if key not in self.label_cache:
+            self.label_cache[key] = dict(labels)
+
+    def iter_statistics(self) -> Iterable[Tuple[LabelDict, List[float]]]:
+        for key, values in self.samples.items():
+            labels = self.label_cache.get(key, {})
+            yield labels, values
+
+
+class MetricsRegistry:
+    """Collect guardrail, critic and latency metrics in-memory."""
+
+    def __init__(self, now: Callable[[], datetime] | None = None) -> None:
+        self._now = now or (lambda: datetime.now(timezone.utc))
+        self.guardrail_verdicts = CounterMetric(
+            name="guardrail_verdict_total",
+            description="Count of guardrail verdict outcomes",
+            label_names=("verdict",),
+        )
+        self.llm_critic_score = GaugeMetric(
+            name="llm_critic_score",
+            description="Latest LLM-Critic score by scenario",
+            label_names=("scenario",),
+        )
+        self.system_latency_ms = HistogramMetric(
+            name="system_latency_ms",
+            description="Distribution of end-to-end latency in milliseconds",
+            label_names=("stage",),
+        )
+
+    # Recording helpers -------------------------------------------------
+    def record_guardrail_verdict(self, verdict: str, weight: float = 1.0) -> None:
+        self.guardrail_verdicts.inc(weight, verdict=verdict)
+
+    def record_llm_critic_score(self, scenario: str, score: float) -> None:
+        self.llm_critic_score.set(score, scenario=scenario)
+
+    def observe_latency(self, latency_ms: float, stage: str = "overall") -> None:
+        self.system_latency_ms.observe(latency_ms, stage=stage)
+
+    # Export helpers ----------------------------------------------------
+    def as_prometheus(self) -> str:
+        lines: List[str] = []
+        # Counters
+        lines.extend(self._prometheus_counter(self.guardrail_verdicts))
+        # Gauges
+        lines.extend(self._prometheus_gauge(self.llm_critic_score))
+        # Histograms
+        lines.extend(self._prometheus_histogram(self.system_latency_ms))
+        return "\n".join(lines) + "\n"
+
+    def as_clickhouse_rows(self) -> List[Dict[str, object]]:
+        timestamp = self._now().isoformat()
+        rows: List[Dict[str, object]] = []
+
+        for key, value in self.guardrail_verdicts.values.items():
+            labels = self.guardrail_verdicts.label_cache[key]
+            rows.append(
+                {
+                    "metric": self.guardrail_verdicts.name,
+                    "value": value,
+                    "type": "counter",
+                    "labels": dict(labels),
+                    "timestamp": timestamp,
+                }
+            )
+
+        for key, value in self.llm_critic_score.values.items():
+            labels = self.llm_critic_score.label_cache[key]
+            rows.append(
+                {
+                    "metric": self.llm_critic_score.name,
+                    "value": value,
+                    "type": "gauge",
+                    "labels": dict(labels),
+                    "timestamp": timestamp,
+                }
+            )
+
+        for labels, values in self.system_latency_ms.iter_statistics():
+            total = sum(values)
+            count = len(values)
+            buckets = self._histogram_bucket_counts(values, self.system_latency_ms.buckets)
+            for bound, bucket_count in buckets.items():
+                bucket_labels = dict(labels)
+                bucket_labels["le"] = bound
+                rows.append(
+                    {
+                        "metric": f"{self.system_latency_ms.name}_bucket",
+                        "value": bucket_count,
+                        "type": "histogram_bucket",
+                        "labels": bucket_labels,
+                        "timestamp": timestamp,
+                    }
+                )
+            rows.append(
+                {
+                    "metric": f"{self.system_latency_ms.name}_sum",
+                    "value": total,
+                    "type": "histogram_sum",
+                    "labels": dict(labels),
+                    "timestamp": timestamp,
+                }
+            )
+            rows.append(
+                {
+                    "metric": f"{self.system_latency_ms.name}_count",
+                    "value": count,
+                    "type": "histogram_count",
+                    "labels": dict(labels),
+                    "timestamp": timestamp,
+                }
+            )
+        return rows
+
+    # Internal helpers --------------------------------------------------
+    def _prometheus_counter(self, metric: CounterMetric) -> List[str]:
+        lines = [f"# HELP {metric.name} {metric.description}", f"# TYPE {metric.name} counter"]
+        for key, value in sorted(metric.values.items()):
+            labels = metric.label_cache[key]
+            label_str = self._format_labels(labels)
+            lines.append(f"{metric.name}{label_str} {value}")
+        return lines
+
+    def _prometheus_gauge(self, metric: GaugeMetric) -> List[str]:
+        lines = [f"# HELP {metric.name} {metric.description}", f"# TYPE {metric.name} gauge"]
+        for key, value in sorted(metric.values.items()):
+            labels = metric.label_cache[key]
+            label_str = self._format_labels(labels)
+            lines.append(f"{metric.name}{label_str} {value}")
+        return lines
+
+    def _prometheus_histogram(self, metric: HistogramMetric) -> List[str]:
+        lines = [f"# HELP {metric.name} {metric.description}", f"# TYPE {metric.name} histogram"]
+        for labels, values in metric.iter_statistics():
+            buckets = metric.buckets
+            counts = self._histogram_bucket_counts(values, buckets)
+            base_label = self._format_labels(labels)
+            cumulative = 0
+            for bound in buckets:
+                cumulative += counts[str(bound)]
+                label_map = dict(labels)
+                label_map["le"] = str(bound)
+                label_str = self._format_labels(label_map)
+                lines.append(f"{metric.name}_bucket{label_str} {cumulative}")
+            cumulative += counts["+Inf"]
+            inf_labels = dict(labels)
+            inf_labels["le"] = "+Inf"
+            lines.append(
+                f"{metric.name}_bucket{self._format_labels(inf_labels)} {cumulative}"
+            )
+            lines.append(f"{metric.name}_sum{base_label} {sum(values)}")
+            lines.append(f"{metric.name}_count{base_label} {len(values)}")
+        return lines
+
+    @staticmethod
+    def _histogram_bucket_counts(values: Iterable[float], buckets: Tuple[float, ...]) -> Dict[str, int]:
+        counts = {str(bound): 0 for bound in buckets}
+        counts["+Inf"] = 0
+        for value in values:
+            placed = False
+            for bound in buckets:
+                if value <= bound:
+                    counts[str(bound)] += 1
+                    placed = True
+                    break
+            if not placed:
+                counts["+Inf"] += 1
+        return counts
+
+    @staticmethod
+    def _format_labels(labels: Mapping[str, str]) -> str:
+        if not labels:
+            return ""
+        formatted = ",".join(
+            f"{key}=\"{value}\"" for key, value in sorted(labels.items())
+        )
+        return f"{{{formatted}}}"

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+from op_observe.telemetry import (
+    ClickHouseExporterConfig,
+    MetricsRegistry,
+    PrometheusExporterConfig,
+    build_collector_config,
+    build_guardrail_dashboard,
+)
+
+
+def test_collector_config_includes_prometheus_and_clickhouse():
+    config = build_collector_config(
+        PrometheusExporterConfig(endpoint="127.0.0.1", port=9000),
+        ClickHouseExporterConfig(table="guard_metrics"),
+    )
+
+    assert "receivers" in config
+    assert config["receivers"]["otlp"]["protocols"] == {"grpc": {}, "http": {}}
+
+    exporters = config["exporters"]
+    assert "prometheus" in exporters
+    assert exporters["prometheus"]["endpoint"] == "127.0.0.1:9000"
+    assert "clickhouse" in exporters
+    assert exporters["clickhouse"]["table"] == "guard_metrics"
+
+    pipeline = config["service"]["pipelines"]["metrics"]
+    assert pipeline["receivers"] == ["otlp"]
+    assert "prometheus" in pipeline["exporters"]
+    assert "clickhouse" in pipeline["exporters"]
+
+
+class _FixedClock:
+    def __init__(self):
+        self._now = datetime(2024, 1, 1)
+
+    def __call__(self):
+        return self._now
+
+
+def test_registry_exports_prometheus_text():
+    clock = _FixedClock()
+    registry = MetricsRegistry(now=clock)
+    registry.record_guardrail_verdict("pass")
+    registry.record_guardrail_verdict("fail", weight=2)
+    registry.record_llm_critic_score("customer_onboarding", 0.87)
+    registry.observe_latency(120, stage="overall")
+    registry.observe_latency(40, stage="retrieval")
+    registry.observe_latency(80, stage="retrieval")
+
+    text = registry.as_prometheus()
+
+    assert "# TYPE guardrail_verdict_total counter" in text
+    assert 'guardrail_verdict_total{verdict="fail"} 2.0' in text
+    assert 'llm_critic_score{scenario="customer_onboarding"} 0.87' in text
+    assert 'system_latency_ms_bucket{le="+Inf",stage="overall"} 1' in text
+    assert 'system_latency_ms_count{stage="retrieval"} 2' in text
+
+
+def test_registry_exports_clickhouse_rows():
+    clock = _FixedClock()
+    registry = MetricsRegistry(now=clock)
+    registry.record_guardrail_verdict("pass")
+    registry.record_llm_critic_score("triage", 0.6)
+    registry.observe_latency(300, stage="overall")
+
+    rows = registry.as_clickhouse_rows()
+    histogram_entries = len(registry.system_latency_ms.buckets) + 1  # +Inf bucket
+    assert len(rows) == 1 + 1 + histogram_entries + 2
+
+    counter = next(row for row in rows if row["metric"] == "guardrail_verdict_total")
+    assert counter["type"] == "counter"
+    assert counter["labels"] == {"verdict": "pass"}
+
+    bucket_rows = [r for r in rows if r["metric"].endswith("_bucket")]
+    assert any(row["labels"]["le"] == "+Inf" for row in bucket_rows)
+    for row in rows:
+        assert row["timestamp"] == datetime(2024, 1, 1).isoformat()
+
+
+def test_grafana_dashboard_has_expected_panels():
+    dashboard = build_guardrail_dashboard()
+    assert dashboard["title"] == "Guardrail & Evals Overview"
+    panel_titles = [panel["title"] for panel in dashboard["panels"]]
+    assert "Guardrail verdicts (rate)" in panel_titles
+    assert "LLM-Critic score" in panel_titles
+    assert "System latency p95" in panel_titles
+    assert dashboard["uid"].startswith("guardrail-")


### PR DESCRIPTION
## Summary
- add telemetry helpers that generate OpenTelemetry collector configurations for Prometheus and ClickHouse
- implement in-memory metrics registry exporting guardrail, critic, and latency metrics to Prometheus text and ClickHouse rows
- provide Grafana dashboard definition and tests covering metrics exports and dashboard structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3ab36e94832b9657cf939f7cf11c