### PR TITLE
Add Phoenix client for OpenInference tracing

### DIFF
--- a/op_observe/observability/__init__.py
+++ b/op_observe/observability/__init__.py
@@ -1,0 +1,20 @@
+"""OpenInference ↔ Phoenix integration utilities."""
+
+from __future__ import annotations
+
+from .phoenix import PhoenixClient, PhoenixTraceExporter
+from .tracing import (
+    OpenInferenceEvaluation,
+    OpenInferenceSpan,
+    OpenInferenceSpanKind,
+    PhoenixTraceSession,
+)
+
+__all__ = [
+    "PhoenixClient",
+    "PhoenixTraceExporter",
+    "PhoenixTraceSession",
+    "OpenInferenceSpan",
+    "OpenInferenceSpanKind",
+    "OpenInferenceEvaluation",
+]

--- a/op_observe/observability/phoenix.py
+++ b/op_observe/observability/phoenix.py
@@ -1,0 +1,139 @@
+"""Phoenix backend client and exporter utilities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Protocol
+from urllib import request
+
+from .tracing import (
+    OpenInferenceEvaluation,
+    OpenInferenceSpan,
+    PhoenixTracePayload,
+)
+
+
+class Transport(Protocol):
+    """Protocol for HTTP transports used by :class:`PhoenixClient`."""
+
+    def post_json(
+        self,
+        url: str,
+        payload: Mapping[str, Any],
+        headers: Mapping[str, str] | None = None,
+    ) -> "TransportResponse":
+        """Send an HTTP POST request with a JSON payload."""
+
+
+@dataclass
+class TransportResponse:
+    """Container for transport responses."""
+
+    status_code: int
+    body: str
+
+    def json(self) -> Any:
+        try:
+            return json.loads(self.body)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError("Transport response did not contain JSON data") from exc
+
+
+class UrllibTransport:
+    """Minimal :mod:`urllib` transport for communicating with Phoenix."""
+
+    def post_json(
+        self,
+        url: str,
+        payload: Mapping[str, Any],
+        headers: Mapping[str, str] | None = None,
+    ) -> TransportResponse:
+        data = json.dumps(payload).encode("utf-8")
+        req = request.Request(url, data=data, method="POST")
+        req.add_header("Content-Type", "application/json")
+        for key, value in (headers or {}).items():
+            req.add_header(key, value)
+        with request.urlopen(req) as resp:  # type: ignore[call-arg]
+            body = resp.read().decode("utf-8")
+            return TransportResponse(resp.status, body)
+
+
+class PhoenixClient:
+    """Thin Phoenix REST client tailored for OpenInference payloads."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        transport: Transport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._transport = transport or UrllibTransport()
+
+    # REST endpoints -----------------------------------------------------
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def upload_trace(self, payload: PhoenixTracePayload) -> TransportResponse:
+        """Send trace data to Phoenix's ingestion endpoint."""
+
+        url = f"{self._base_url}/api/v1/traces"
+        payload_mapping = {"trace_id": payload.trace_id, "spans": payload.spans}
+        return self._transport.post_json(url, payload_mapping, headers=self._headers())
+
+    def upload_evaluations(
+        self,
+        trace_id: str,
+        evaluations: Iterable[OpenInferenceEvaluation],
+    ) -> TransportResponse:
+        """Push evaluation metrics associated with a trace."""
+
+        url = f"{self._base_url}/api/v1/evaluations"
+        payload = {
+            "trace_id": trace_id,
+            "evaluations": [evaluation.to_wire() for evaluation in evaluations],
+        }
+        return self._transport.post_json(url, payload, headers=self._headers())
+
+    def refresh_dashboards(self, trace_id: str) -> TransportResponse:
+        """Request that Phoenix refresh dashboards for the provided trace."""
+
+        url = f"{self._base_url}/api/v1/dashboards/refresh"
+        payload = {"trace_id": trace_id}
+        return self._transport.post_json(url, payload, headers=self._headers())
+
+
+class PhoenixTraceExporter:
+    """Push :class:`OpenInferenceSpan` batches to Phoenix."""
+
+    def __init__(self, client: PhoenixClient) -> None:
+        self._client = client
+
+    def export(
+        self,
+        trace_id: str,
+        spans: Iterable[OpenInferenceSpan],
+        evaluations: Iterable[OpenInferenceEvaluation],
+    ) -> MutableMapping[str, TransportResponse]:
+        """Send a set of spans + evaluations to Phoenix and refresh dashboards."""
+
+        span_payload = PhoenixTracePayload(
+            trace_id=trace_id,
+            spans=[span.to_wire() for span in spans],
+        )
+        responses: Dict[str, TransportResponse] = {}
+        responses["traces"] = self._client.upload_trace(span_payload)
+        evaluations = list(evaluations)
+        if evaluations:
+            responses["evaluations"] = self._client.upload_evaluations(
+                trace_id,
+                evaluations,
+            )
+        responses["dashboards"] = self._client.refresh_dashboards(trace_id)
+        return responses

--- a/op_observe/observability/tracing.py
+++ b/op_observe/observability/tracing.py
@@ -1,0 +1,216 @@
+"""OpenInference span abstractions and Phoenix session helpers."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Mapping, MutableMapping
+
+if TYPE_CHECKING:
+    from .phoenix import PhoenixTraceExporter, TransportResponse
+
+
+class OpenInferenceSpanKind(str, Enum):
+    """Semantic span categories supported by OpenInference."""
+
+    MODEL = "llm"
+    RETRIEVER = "retriever"
+    TOOL = "tool"
+    CHAIN = "chain"
+
+    def attribute_name(self) -> str:
+        """Return the canonical attribute storing the semantic identifier."""
+
+        return {
+            OpenInferenceSpanKind.MODEL: "openinference.model.name",
+            OpenInferenceSpanKind.RETRIEVER: "openinference.retriever.name",
+            OpenInferenceSpanKind.TOOL: "openinference.tool.name",
+            OpenInferenceSpanKind.CHAIN: "openinference.chain.name",
+        }[self]
+
+
+@dataclass
+class OpenInferenceSpan:
+    """Structured representation of an OpenInference span."""
+
+    name: str
+    kind: OpenInferenceSpanKind
+    start_time: float
+    end_time: float
+    attributes: MutableMapping[str, Any] = field(default_factory=dict)
+    span_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    parent_id: str | None = None
+    trace_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def to_wire(self) -> Dict[str, Any]:
+        """Serialise span data into the structure expected by Phoenix."""
+
+        payload: Dict[str, Any] = {
+            "span_id": self.span_id,
+            "trace_id": self.trace_id,
+            "parent_id": self.parent_id,
+            "name": self.name,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "attributes": {
+                "openinference.span.kind": self.kind.value,
+                **self.attributes,
+            },
+        }
+        return payload
+
+
+@dataclass
+class OpenInferenceEvaluation:
+    """Evaluation record tied to a specific span or trace."""
+
+    metric_name: str
+    value: float
+    span_id: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def to_wire(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "metric_name": self.metric_name,
+            "value": self.value,
+        }
+        if self.span_id:
+            payload["span_id"] = self.span_id
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass
+class PhoenixTracePayload:
+    """Wire representation of a Phoenix trace payload."""
+
+    trace_id: str
+    spans: List[Mapping[str, Any]]
+
+
+class PhoenixTraceSession:
+    """High-level helper to build and submit traces to Phoenix."""
+
+    def __init__(
+        self,
+        exporter: "PhoenixTraceExporter",
+        *,
+        trace_id: str | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        from .phoenix import PhoenixTraceExporter  # circular import guard
+
+        if not isinstance(exporter, PhoenixTraceExporter):  # pragma: no cover - defensive
+            raise TypeError("exporter must be a PhoenixTraceExporter instance")
+
+        self._exporter = exporter
+        self._trace_id = trace_id or uuid.uuid4().hex
+        self._clock = clock or time.time
+        self._spans: List[OpenInferenceSpan] = []
+        self._evaluations: List[OpenInferenceEvaluation] = []
+        self._span_stack: List[OpenInferenceSpan] = []
+
+    @property
+    def trace_id(self) -> str:
+        return self._trace_id
+
+    def record_evaluation(
+        self,
+        metric_name: str,
+        value: float,
+        *,
+        span: OpenInferenceSpan | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> OpenInferenceEvaluation:
+        """Attach an evaluation metric to the trace (optionally to a span)."""
+
+        evaluation = OpenInferenceEvaluation(
+            metric_name=metric_name,
+            value=value,
+            span_id=span.span_id if span else None,
+            metadata=metadata,
+        )
+        self._evaluations.append(evaluation)
+        return evaluation
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        kind: OpenInferenceSpanKind,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[OpenInferenceSpan]:
+        """Context manager for building nested OpenInference spans."""
+
+        start_time = float(self._clock())
+        parent = self._span_stack[-1] if self._span_stack else None
+        span = OpenInferenceSpan(
+            name=name,
+            kind=kind,
+            start_time=start_time,
+            end_time=start_time,  # placeholder; updated on exit
+            trace_id=self._trace_id,
+            parent_id=parent.span_id if parent else None,
+            attributes=dict(attributes or {}),
+        )
+        semantic_key = kind.attribute_name()
+        if semantic_key not in span.attributes:
+            span.attributes[semantic_key] = name
+        self._span_stack.append(span)
+        try:
+            yield span
+        finally:
+            span.end_time = float(self._clock())
+            self._spans.append(span)
+            self._span_stack.pop()
+
+    def submit(self) -> MutableMapping[str, "TransportResponse"]:
+        """Export the captured spans and evaluations via the bound exporter."""
+
+        return self._exporter.export(
+            self._trace_id,
+            list(self._spans),
+            list(self._evaluations),
+        )
+
+    # Convenience methods -------------------------------------------------
+    def model_span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[OpenInferenceSpan]:
+        return self.span(name, kind=OpenInferenceSpanKind.MODEL, attributes=attributes)
+
+    def tool_span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[OpenInferenceSpan]:
+        return self.span(name, kind=OpenInferenceSpanKind.TOOL, attributes=attributes)
+
+    def retriever_span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[OpenInferenceSpan]:
+        return self.span(
+            name,
+            kind=OpenInferenceSpanKind.RETRIEVER,
+            attributes=attributes,
+        )
+
+    def chain_span(
+        self,
+        name: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[OpenInferenceSpan]:
+        return self.span(name, kind=OpenInferenceSpanKind.CHAIN, attributes=attributes)

--- a/tests/test_phoenix_integration.py
+++ b/tests/test_phoenix_integration.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from op_observe.observability import (
+    OpenInferenceSpanKind,
+    PhoenixClient,
+    PhoenixTraceExporter,
+    PhoenixTraceSession,
+)
+from op_observe.observability.phoenix import TransportResponse
+
+
+class FakeClock:
+    def __init__(self, start: float = 1_000.0, step: float = 0.5) -> None:
+        self._value = start
+        self._step = step
+
+    def __call__(self) -> float:
+        current = self._value
+        self._value += self._step
+        return current
+
+
+class RecordingTransport:
+    def __init__(self) -> None:
+        self.requests: List[Dict[str, Any]] = []
+
+    def post_json(
+        self,
+        url: str,
+        payload: Dict[str, Any],
+        headers: Dict[str, str] | None = None,
+    ) -> TransportResponse:
+        self.requests.append({"url": url, "payload": payload, "headers": headers or {}})
+        return TransportResponse(status_code=200, body=json.dumps({"status": "ok"}))
+
+
+@pytest.fixture()
+def phoenix_components() -> tuple[PhoenixTraceSession, RecordingTransport]:
+    transport = RecordingTransport()
+    client = PhoenixClient("https://phoenix.example", transport=transport)
+    exporter = PhoenixTraceExporter(client)
+    session = PhoenixTraceSession(exporter, trace_id="trace-123", clock=FakeClock())
+    return session, transport
+
+
+def test_trace_session_exports_openinference_spans(phoenix_components: tuple[PhoenixTraceSession, RecordingTransport]) -> None:
+    session, transport = phoenix_components
+
+    with session.chain_span("agent-flow"):
+        with session.model_span(
+            "gpt-4",
+            attributes={"openinference.model.name": "gpt-4", "llm.temperature": 0.0},
+        ) as model_span:
+            with session.tool_span("bing-search", attributes={"tool.args": {"q": "phoenix"}}):
+                pass
+        with session.retriever_span("qdrant"):
+            pass
+
+    session.record_evaluation(
+        "accuracy",
+        0.93,
+        span=model_span,
+        metadata={"dataset": "eval-set", "threshold": 0.9},
+    )
+    responses = session.submit()
+
+    assert set(responses.keys()) == {"traces", "evaluations", "dashboards"}
+    assert len(transport.requests) == 3
+
+    trace_request = transport.requests[0]
+    assert trace_request["url"].endswith("/api/v1/traces")
+    assert trace_request["payload"]["trace_id"] == "trace-123"
+    spans = trace_request["payload"]["spans"]
+    kinds = {span["attributes"]["openinference.span.kind"] for span in spans}
+    assert {"chain", "llm", "tool", "retriever"} == kinds
+
+    llm_spans = [
+        span
+        for span in spans
+        if span["attributes"].get("openinference.span.kind") == OpenInferenceSpanKind.MODEL.value
+    ]
+    assert llm_spans, "Expected at least one LLM span"
+    llm_span = llm_spans[0]
+    assert llm_span["attributes"]["openinference.model.name"] == "gpt-4"
+    assert llm_span["attributes"]["llm.temperature"] == 0.0
+
+    tool_spans = [
+        span
+        for span in spans
+        if span["attributes"]["openinference.span.kind"] == OpenInferenceSpanKind.TOOL.value
+    ]
+    assert tool_spans[0]["attributes"]["openinference.tool.name"] == "bing-search"
+    retriever_spans = [
+        span
+        for span in spans
+        if span["attributes"]["openinference.span.kind"] == OpenInferenceSpanKind.RETRIEVER.value
+    ]
+    assert retriever_spans[0]["attributes"]["openinference.retriever.name"] == "qdrant"
+
+    eval_request = transport.requests[1]
+    assert eval_request["url"].endswith("/api/v1/evaluations")
+    assert eval_request["payload"]["trace_id"] == "trace-123"
+    evaluation_payload = eval_request["payload"]["evaluations"][0]
+    assert evaluation_payload["metric_name"] == "accuracy"
+    assert pytest.approx(evaluation_payload["value"], rel=1e-6) == 0.93
+    assert evaluation_payload["metadata"] == {"dataset": "eval-set", "threshold": 0.9}
+    assert evaluation_payload["span_id"] == model_span.span_id
+
+    dashboard_request = transport.requests[2]
+    assert dashboard_request["url"].endswith("/api/v1/dashboards/refresh")
+    assert dashboard_request["payload"] == {"trace_id": "trace-123"}


### PR DESCRIPTION
## Summary
- add an `observability` module that exposes Phoenix clients, exporters, and OpenInference span helpers
- ensure trace exports include model/tool/retriever semantics and evaluation metrics when pushing to Phoenix endpoints
- cover the integration with tests that assert Phoenix receives spans enriched with OpenInference attributes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca3b02fd74832b9f29821cc2fea5c2